### PR TITLE
minmoji => noto sans

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -22,16 +22,6 @@ export default {
 
 
 <style>
-@font-face {
-  font-family: minmoji;
-  src: url("https://minmoji.ucda.jp/fontseot/https%3A__yamanoku.net");
-  src: local("minmoji"),
-    url("https://minmoji.ucda.jp/fontswoff/https%3A__yamanoku.net")
-      format("woff"),
-    url("https://minmoji.ucda.jp/fonts/https%3A__yamanoku.net")
-      format("opentype");
-  font-display: swap;
-}
 :root {
   --black: rgb(21, 32, 43);
   --white: rgb(210, 210, 210);
@@ -47,6 +37,7 @@ html {
   font: inherit;
   font-size: 100%;
   line-height: var(--rhythm);
+  overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
 }
 body {
@@ -55,7 +46,7 @@ body {
   font-weight: 400;
 }
 html[lang="ja"] body {
-  font-family: minmoji, Arial, Helvetica, sans-serif;
+  font-family: "Noto Sans", "Noto Sans CJK JP", "Noto Sans JP", sans-serif;
 }
 body.is-rhythm {
   position: relative;
@@ -285,12 +276,5 @@ pre {
 }
 code.hljs {
   padding: var(--rhythm);
-}
-a[href="https://minmoji.ucda.jp/"] {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  clip: rect(1px, 1px, 1px, 1px);
 }
 </style>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -38,15 +38,9 @@ module.exports = {
       { name: "og:image", content: baseOgp }
     ],
     link: [
-      { rel: "icon", type: "image/x-icon", href: "/favicon.ico" }
+      { rel: "icon", type: "image/x-icon", href: "/favicon.ico" },
+      { rel: "stylesheet", href: "https://fonts.googleapis.com/css?family=Noto+Sans+JP:400,700&amp;display=optional" }
     ],
-    script: [
-      // TODO: Use Font Loading API
-      {
-        src: "https://minmoji.ucda.jp/sealjs/https%3A__yamanoku.net",
-        charset: "UTF-8"
-      }
-    ]
   },
   css: ["modern-normalize"],
   build: {

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -32,9 +32,6 @@
               <a href="#do-not-over-design">{{$t("aboutPage.subHeading.overdesign")}}</a>
             </li>
             <li role="listitem">
-              <a href="#japanese-font-family">{{$t("aboutPage.subHeading.JPFont")}}</a>
-            </li>
-            <li role="listitem">
               <a href="#font-size">{{$t("aboutPage.subHeading.fontSize")}}</a>
             </li>
             <li role="listitem">
@@ -72,7 +69,6 @@
       </h3>
       <p>{{$t("aboutPage.designDescription")}}</p>
       <do-not-over-design />
-      <japanese-font-family />
       <font-size-article />
       <color-contrast />
       <max-width-article />
@@ -93,7 +89,6 @@ import I18nArticle from "~/components/about-articles/I18n.vue";
 
 // section-design
 import DoNotOverDesign from "~/components/about-articles/DoNotOverDesign.vue";
-import JapaneseFontFamily from "~/components/about-articles/JapaneseFontFamily.vue";
 import FontSizeArticle from "~/components/about-articles/FontSize.vue";
 import ColorContrast from "~/components/about-articles/ColorContrast.vue";
 import MaxWidthArticle from "~/components/about-articles/MaxWidth.vue";
@@ -121,7 +116,6 @@ export default {
     PwaArticle,
     I18nArticle,
     DoNotOverDesign,
-    JapaneseFontFamily,
     FontSizeArticle,
     ColorContrast,
     MaxWidthArticle,

--- a/vueI18n.js
+++ b/vueI18n.js
@@ -105,7 +105,6 @@ export default {
           pwa: "PWA (Progressive Web Application)",
           i18n: "Internationalization",
           overdesign: "Don't overdesign.",
-          JPFont: "About Japanese fonts",
           fontSize: "Font size",
           contrast: "Color contrast",
           maxWidth: "About the greatest amount of content",
@@ -132,9 +131,6 @@ export default {
         overdesign: {
           desc01: "Too much decoration can prevent you from getting the information you want. It is designed with the default style of the browser, that is, the standard image in mind.",
           desc02: "It's also designed with semantic markup, so you can get to the information without getting stylized or leaving the default style.",
-        },
-        JPFont: {
-          desc01: "The UD font Minna no Moji ® WEB font is used.",
         },
         fontSize: {
           desc01: "The basic setting is 16 px, and the size ratio can be maintained even if the page is enlarged by rem."
@@ -291,7 +287,6 @@ export default {
           pwa: "PWA (Progressive Web Application)",
           i18n: "国際化対応",
           overdesign: "オーバーデザインしすぎない",
-          JPFont: "日本語フォントについて",
           fontSize: "文字サイズ",
           contrast: "カラーコントラスト",
           maxWidth: "最大幅について",
@@ -318,9 +313,6 @@ export default {
         overdesign: {
           desc01: "過剰な装飾をしすぎることは目的の情報にたどり着く阻害に成り得ます。ブラウザのデフォルトスタイル、つまり標準の姿を意識したデザインにしています。",
           desc02: "また、セマンティクスなマークアップで設計していることで、スタイルを外してもデフォルトスタイルのままでも違和感なく情報にたどり着けるようにも繋がります。",
-        },
-        JPFont: {
-          desc01: "UDフォントであるみんなの文字®WEBフォントを使用しています。",
         },
         fontSize: {
           desc01: "基本16pxになるように設定しており、ページを拡大してもサイズ比を維持したremで指定しています。"
@@ -476,7 +468,6 @@ export default {
           pwa: "PWA (Progressive Web Application)",
           i18n: "Internationalisation",
           overdesign: "Ne surconcevez pas.",
-          JPFont: "A propos des polices japonaises",
           fontSize: "Taille du texte",
           contrast: "Contraste de couleur",
           maxWidth: "A propos de la largeur de contenu maximale",
@@ -503,9 +494,6 @@ export default {
         overdesign: {
           desc01: "Trop de décoration peut vous empêcher d'obtenir l'information que vous voulez. Il est conçu avec le style par défaut du navigateur, c'est-à-dire l'image standard en tête.",
           desc02: "Il est également implémenté dans un balisage sémantique, de sorte que vous pouvez accéder à l'information sans être stylisé ou laisser le style par défaut.",
-        },
-        JPFont: {
-          desc01: "Nous utilisons la police Minna no Moji ® WEB qui est une police UD (conception universelle).",
         },
         fontSize: {
           desc01: "Le paramètre de base est 16 px, et le rapport taille est maintenu lorsque la page est agrandie par rem."


### PR DESCRIPTION
- FOUTをどうにかするのが現実的ではなく感じる
  - Font Loading APIだけで解決出来たら良さそうと思うが
  - それだけで解決できること以外の問題もあった

- フリーでのUDフォントを使えるのが現実的ではなかった
  - minmojiはフリーで使用する場合script読み込みで以下ロゴを出す必要がある
  - ![https://minmoji.ucda.jp/pages/wp-content/themes/minmoji2017/images/btn_ucda_20151222.jpg](https://minmoji.ucda.jp/pages/wp-content/themes/minmoji2017/images/btn_ucda_20151222.jpg)
  - yamanoku.netではvisually-hiddenで視覚情報としては隠していた（ `<div id="__nuxt">` より上に出てレイアウトを壊すため）
  - 別窓リンクで `rel="noopener"` が付与されていないためlighthouseで減点対象
  - chでの幅指定のため、フォント読み込み完了時に幅のカクつきがある

というわけでUDフォント使用はディスレクシア対応以外にも負荷がかかりそうなので一旦廃止する

