### PR TITLE
add:generate error option

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "nuxt",
     "build": "nuxt build",
     "start": "nuxt start",
-    "generate": "nuxt generate && rm dist/_nuxt/**.js && rm dist/config.js",
+    "generate": "nuxt generate --fail-on-error && rm dist/_nuxt/**.js && rm dist/config.js",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",
     "lintfix": "eslint --fix --ext .js,.vue --ignore-path .gitignore .",
     "precommit": "npm run lint",


### PR DESCRIPTION
generate時にページ生成エラーが帰ってこなくて
CIが通ってしまうので`--fail-on-error`オプションを追加