### PR TITLE
fix:meta title

### DIFF
--- a/mixins/meta.js
+++ b/mixins/meta.js
@@ -13,7 +13,7 @@ export default {
       bodyAttrs: {}
     }
     if (this.meta.title) {
-      const title = `${this.meta.title} - ${this.baseName}`
+      const title = `${this.meta.title} - yamanoku.net`
       head.title = title
       head.meta.push({ hid: "og:title", property: "og:title", content: title })
     }


### PR DESCRIPTION
<img width="277" alt="Screen Shot 2020-06-14 at 8 49 51" src="https://user-images.githubusercontent.com/1996642/84581453-09812f80-ae1c-11ea-886c-a9fd1689856a.png">

titleの`yamanoku.net`箇所がundefinedになってるので応急処置
env側が悪い気がする