### PR TITLE
add:image ratio

### DIFF
--- a/components/products/AccessibilityBeginner.vue
+++ b/components/products/AccessibilityBeginner.vue
@@ -17,6 +17,7 @@
         />
         <img
           src="~/assets/img/product-web-accessibility-for-beginner.jpg"
+          width="663" height="480"
           :alt="$t('prefixAlt.photo') + $t('product.wafb.title')"
         />
       </picture>

--- a/components/products/AccessibilityBeginner.vue
+++ b/components/products/AccessibilityBeginner.vue
@@ -17,7 +17,8 @@
         />
         <img
           src="~/assets/img/product-web-accessibility-for-beginner.jpg"
-          width="663" height="480"
+          width="663"
+          height="480"
           :alt="$t('prefixAlt.photo') + $t('product.wafb.title')"
         />
       </picture>

--- a/components/products/Reading.vue
+++ b/components/products/Reading.vue
@@ -9,7 +9,8 @@
         <source srcset="~/assets/img/product-reading.webp" type="image/webp" />
         <img
           src="~/assets/img/product-reading.png"
-          width="688" height="498"
+          width="688"
+          height="498"
           :alt="$t('prefixAlt.screenshot') + $t('product.reading')"
         />
       </picture>

--- a/components/products/Reading.vue
+++ b/components/products/Reading.vue
@@ -9,6 +9,7 @@
         <source srcset="~/assets/img/product-reading.webp" type="image/webp" />
         <img
           src="~/assets/img/product-reading.png"
+          width="688" height="498"
           :alt="$t('prefixAlt.screenshot') + $t('product.reading')"
         />
       </picture>

--- a/components/products/VuePortfolio.vue
+++ b/components/products/VuePortfolio.vue
@@ -17,6 +17,7 @@
         />
         <img
           src="~/assets/img/product-vue-portfolio-template.png"
+          width="688" height="498"
           :alt="$t('prefixAlt.screenshot') + $t('product.vuePortfolio')"
         />
       </picture>

--- a/components/products/VuePortfolio.vue
+++ b/components/products/VuePortfolio.vue
@@ -17,7 +17,8 @@
         />
         <img
           src="~/assets/img/product-vue-portfolio-template.png"
-          width="688" height="498"
+          width="688"
+          height="498"
           :alt="$t('prefixAlt.screenshot') + $t('product.vuePortfolio')"
         />
       </picture>

--- a/components/products/VuejsAccessibilityPage.vue
+++ b/components/products/VuejsAccessibilityPage.vue
@@ -17,7 +17,8 @@
         />
         <img
           src="~/assets/img/product-about-accessibility-with-vuejs.png"
-          width="688" height="498"
+          width="688"
+          height="498"
           :alt="$t('prefixAlt.photo') + $t('product.vueA11yPage.title')"
         />
       </picture>

--- a/components/products/VuejsAccessibilityPage.vue
+++ b/components/products/VuejsAccessibilityPage.vue
@@ -17,6 +17,7 @@
         />
         <img
           src="~/assets/img/product-about-accessibility-with-vuejs.png"
+          width="688" height="498"
           :alt="$t('prefixAlt.photo') + $t('product.vueA11yPage.title')"
         />
       </picture>


### PR DESCRIPTION
resolve: Image elements do not have explicit width and height
Set an explicit width and height on image elements to reduce layout shifts and improve CLS

https://web.dev/optimize-cls/#images-without-dimensions