### PR TITLE
settings noto sans font

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -23,7 +23,7 @@ html:not([lang="ja"]) body {
   hyphens: auto;
 }
 html[lang="ja"] body {
-  font-family: "Noto Sans", "Noto Sans CJK JP", "Noto Sans JP", sans-serif;
+  font-family: Noto Sans JP, sans-serif;
   line-break: loose;
 }
 html[lang="ja"] main,


### PR DESCRIPTION
<img width="773" alt="Screen Shot 2021-01-02 at 16 58 17" src="https://user-images.githubusercontent.com/1996642/103453285-bae5a500-4d1b-11eb-98db-28615733e1e4.png">
適応されてない