### PR TITLE
fix: article => section

### DIFF
--- a/components/about-sections/ColorContrast.vue
+++ b/components/about-sections/ColorContrast.vue
@@ -1,5 +1,5 @@
 <template>
-  <article
+  <section
     id="about:color-contrast"
     aria-labelledby="about:color-contrast_heading"
   >
@@ -28,7 +28,7 @@
       </dl>
       <p>{{ $t("aboutPage.contrast.desc03") }}</p>
     </details>
-  </article>
+  </section>
 </template>
 
 <script>

--- a/components/about-sections/ComponentOriented.vue
+++ b/components/about-sections/ComponentOriented.vue
@@ -1,5 +1,5 @@
 <template>
-  <article
+  <section
     id="about:component-oriented"
     aria-labelledby="about:component-oriented_heading"
   >
@@ -28,7 +28,7 @@
         </figcaption>
       </figure>
     </details>
-  </article>
+  </section>
 </template>
 
 <script>

--- a/components/about-sections/DoNotOverDesign.vue
+++ b/components/about-sections/DoNotOverDesign.vue
@@ -1,5 +1,5 @@
 <template>
-  <article
+  <section
     id="about:do-not-over-design"
     aria-labelledby="about:do-not-over-design_heading"
   >
@@ -21,5 +21,5 @@
         </a>
       </li>
     </ul>
-  </article>
+  </section>
 </template>

--- a/components/about-sections/FontSize.vue
+++ b/components/about-sections/FontSize.vue
@@ -1,8 +1,8 @@
 <template>
-  <article id="about:font-size" aria-labelledby="about:font-size_heading">
+  <section id="about:font-size" aria-labelledby="about:font-size_heading">
     <h3 id="about:font-size_heading">
       {{ $t("aboutPage.subHeading.fontSize") }}
     </h3>
     <p>{{ $t("aboutPage.fontSize.desc01") }}</p>
-  </article>
+  </section>
 </template>

--- a/components/about-sections/Internationalization.vue
+++ b/components/about-sections/Internationalization.vue
@@ -1,5 +1,5 @@
 <template>
-  <article
+  <section
     id="about:internationalization"
     aria-labelledby="about:internationalization_heading"
   >
@@ -28,7 +28,7 @@
         </figcaption>
       </figure>
     </details>
-  </article>
+  </section>
 </template>
 
 <script>

--- a/components/about-sections/Markup.vue
+++ b/components/about-sections/Markup.vue
@@ -1,5 +1,5 @@
 <template>
-  <article id="about:markup" aria-labelledby="about:markup_heading">
+  <section id="about:markup" aria-labelledby="about:markup_heading">
     <h3 id="about:markup_heading">{{ $t("aboutPage.subHeading.markup") }}</h3>
     <p>{{ $t("aboutPage.markup.desc01") }}</p>
     <p>{{ $t("aboutPage.markup.desc02") }}</p>
@@ -26,7 +26,7 @@
         </figcaption>
       </figure>
     </details>
-  </article>
+  </section>
 </template>
 
 <script>
@@ -34,11 +34,11 @@ export default {
   data() {
     return {
       waiAria: `
-  <article id="about:markup" aria-labelledby="about:markup_heading">
+  <section id="about:markup" aria-labelledby="about:markup_heading">
     <h3 id="about:markup_heading">
       {{$t("aboutPage.subHeading.markup")}}
     </h3>
-  </article>
+  </section>
       `
     };
   }

--- a/components/about-sections/MaxWidth.vue
+++ b/components/about-sections/MaxWidth.vue
@@ -1,9 +1,9 @@
 <template>
-  <article id="about:max-width" aria-labelledby="about:max-width_heading">
+  <section id="about:max-width" aria-labelledby="about:max-width_heading">
     <h3 id="about:max-width_heading">
       {{ $t("aboutPage.subHeading.maxWidth") }}
     </h3>
     <p>{{ $t("aboutPage.maxWidth.desc01") }}</p>
     <p>{{ $t("aboutPage.maxWidth.desc02") }}</p>
-  </article>
+  </section>
 </template>

--- a/components/about-sections/ProgressiveWebApplication.vue
+++ b/components/about-sections/ProgressiveWebApplication.vue
@@ -1,5 +1,5 @@
 <template>
-  <article
+  <section
     id="about:progressive-web-application"
     aria-labelledby="about:progressive-web-application_heading"
   >
@@ -21,5 +21,5 @@
         </a>
       </li>
     </ul>
-  </article>
+  </section>
 </template>

--- a/components/about-sections/TechStack.vue
+++ b/components/about-sections/TechStack.vue
@@ -1,5 +1,5 @@
 <template>
-  <article id="about:tech-stack" aria-labelledby="about:tech-stack_heading">
+  <section id="about:tech-stack" aria-labelledby="about:tech-stack_heading">
     <h3 id="about:tech-stack_heading">
       {{ $t("heading.techStack") }}
     </h3>
@@ -26,5 +26,5 @@
       <li role="listitem">modern-normalize</li>
       <li role="listitem">Google Fonts</li>
     </ul>
-  </article>
+  </section>
 </template>

--- a/components/about-sections/VerticalRhythm.vue
+++ b/components/about-sections/VerticalRhythm.vue
@@ -1,5 +1,5 @@
 <template>
-  <article
+  <section
     id="about:vertical-rhythm"
     aria-labelledby="about:vertical-rhythm_heading"
   >
@@ -9,5 +9,5 @@
     <p>{{ $t("aboutPage.verticalRhythm.desc01") }}</p>
     <p>{{ $t("aboutPage.verticalRhythm.desc02") }}</p>
     <buttons-switch-rhythm-btn />
-  </article>
+  </section>
 </template>

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -74,22 +74,22 @@
       <h2 id="about:implementation_heading">
         {{ $t("aboutPage.heading.implementation") }}
       </h2>
-      <about-articles-tech-stack />
-      <about-articles-markup />
-      <about-articles-component-oriented />
-      <about-articles-progressive-web-application />
-      <about-articles-internationalization />
+      <about-sections-tech-stack />
+      <about-sections-markup />
+      <about-sections-component-oriented />
+      <about-sections-progressive-web-application />
+      <about-sections-internationalization />
     </section>
     <section id="about:design" aria-labelledby="about:design_heading">
       <h2 id="about:design_heading">
         {{ $t("aboutPage.heading.design") }}
       </h2>
       <p>{{ $t("aboutPage.designDescription") }}</p>
-      <about-articles-do-not-over-design />
-      <about-articles-font-size />
-      <about-articles-color-contrast />
-      <about-articles-max-width />
-      <about-articles-vertical-rhythm />
+      <about-sections-do-not-over-design />
+      <about-sections-font-size />
+      <about-sections-color-contrast />
+      <about-sections-max-width />
+      <about-sections-vertical-rhythm />
     </section>
     <nuxt-link :to="localePath({ name: 'index' })">{{
       $t("backTop")


### PR DESCRIPTION
`<article>` で置いていたが、仕様書を見るに使い方が違うとおもったので `<section>` に変更した。

> article要素は、文書、ページ、アプリケーション、またはサイトの中で完全もしくは自己完結した構造を表す。
> ...
> これは、フォーラムの投稿、雑誌や新聞の記事、ブログのエントリー、ユーザーの投稿コメント、対話的なウィジェットやガジェット、またはコンテンツの任意の独立した項目であるかもしれない。
> [HTML Standard 日本語訳](https://momdo.github.io/html/sections.html#the-article-element)