### PR TITLE
Add: role=img

### DIFF
--- a/assets/svg-icons/ImageIcon.vue
+++ b/assets/svg-icons/ImageIcon.vue
@@ -1,5 +1,6 @@
 <template>
   <svg
+    role="img"
     xmlns="http://www.w3.org/2000/svg"
     width="24"
     height="24"

--- a/assets/svg-icons/MailIcon.vue
+++ b/assets/svg-icons/MailIcon.vue
@@ -1,5 +1,6 @@
 <template>
   <svg
+    role="img"
     xmlns="http://www.w3.org/2000/svg"
     width="24"
     height="24"

--- a/assets/svg-icons/OpenNewIcon.vue
+++ b/assets/svg-icons/OpenNewIcon.vue
@@ -1,5 +1,6 @@
 <template>
   <svg
+    role="img"
     xmlns="http://www.w3.org/2000/svg"
     width="24"
     height="24"


### PR DESCRIPTION
> ページに埋め込み SVG 画像を使用している場合は、外側の <svg> 要素で role="img" を設定し、ラベルを付けることをお勧めします。 
https://developer.mozilla.org/ja/docs/Web/Accessibility/ARIA/Roles/Role_Img#svg_and_roleimg

title が入っているのでラベルは不要