### PR TITLE
Fix: Safari Reader Mode Viewer

### DIFF
--- a/components/about-sections/ComponentOriented.vue
+++ b/components/about-sections/ComponentOriented.vue
@@ -37,21 +37,22 @@ export default {
     return {
       slide: `
 <ul role="list">
-  <li role="listitem" v-for="list in listItem" :key="list.title">
+  <li role="listitem" v-for="list in listItem" :key="list.index">
     <template v-if="list.datetime">
-      <time :datetime="list.datetime">
-        {{dateReplace(list.datetime)}}
-      </time>
+      <span class="time">{{
+        dateStirngReplace(list.datetime)
+      }}</span>
       -
     </template>
-    <template v-if="list.created_at">
-      <time :datetime="list.created_at">
-        {{dateCreated(list.created_at)}}
-      </time>
+    <template v-else-if="list.created_at">
+      <span class="time">{{
+        dateStirngReplace(list.created_at)
+      }}</span>
       -
     </template>
     <a :href="list.url" target="_blank" rel="noopener" lang="ja">
-      {{list.title}}
+      {{ list.title }}
+      <open-new-icon />
     </a>
   </li>
 </ul>

--- a/components/global/SlideList.vue
+++ b/components/global/SlideList.vue
@@ -2,15 +2,11 @@
   <ul role="list">
     <li role="listitem" v-for="list in listItem" :key="list.index">
       <template v-if="list.datetime">
-        <time :datetime="dateTimeReplace(list.datetime)">{{
-          dateStirngReplace(list.datetime)
-        }}</time>
+        <span class="time">{{ dateStirngReplace(list.datetime) }}</span>
         -
       </template>
       <template v-else-if="list.created_at">
-        <time :datetime="dateTimeReplace(list.created_at)">{{
-          dateStirngReplace(list.created_at)
-        }}</time>
+        <span class="time">{{ dateStirngReplace(list.created_at) }}</span>
         -
       </template>
       <a :href="list.url" target="_blank" rel="noopener" lang="ja">
@@ -32,9 +28,6 @@ export default {
     };
   },
   methods: {
-    dateTimeReplace(date) {
-      return date.replace(/T.*$/, "");
-    },
     dateStirngReplace(date) {
       return date.replace(/T.*$/, "").replace(/(-)/g, "/");
     }

--- a/components/products/VuejsAccessibilityPage.vue
+++ b/components/products/VuejsAccessibilityPage.vue
@@ -40,11 +40,11 @@
       </h4>
       <ul>
         <li>
-          <time datetime="2019-12-21">2019/12/21</time>
+          <span class="time">2019/12/21</span>
           {{ $t("product.vueA11yPage.info.listitem01") }}
         </li>
         <li>
-          <time datetime="2020-02-28">2020/02/28</time>
+          <span class="time">2020/02/28</span>
           <i18n path="product.vueA11yPage.info.listitem02">
             <template v-slot:awesomeA11yVue>
               <a
@@ -58,7 +58,7 @@
           </i18n>
         </li>
         <li>
-          <time datetime="2020-05-03">2020/05/03</time>
+          <span class="time">2020/05/03</span>
           {{ $t("product.vueA11yPage.info.listitem03") }}
         </li>
       </ul>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -57,7 +57,7 @@ body.is-rhythm::after {
   width: auto;
   z-index: 9999;
 }
-ul:not([class]) li time {
+ul:not([class]) li .time {
   font-variant-numeric: tabular-nums;
 }
 ul:not([class]) li svg {


### PR DESCRIPTION
Safari (Version 14.1) にて確認。
謎の日付が上に来ていたり、vue-a11y の「このドキュメントに関する情報」の一覧が見えなくなっている。

<img width="480" alt="Screen Shot 2021-07-03 at 18 29 40" src="https://user-images.githubusercontent.com/1996642/124350955-97e86f00-dc32-11eb-9a26-badb232047dc.png">
<img width="480" alt="Screen Shot 2021-07-03 at 18 29 44" src="https://user-images.githubusercontent.com/1996642/124350957-99b23280-dc32-11eb-80dc-1467e77af9b7.png">

細かい原因までは特定できなかったが、どうやら `time` 要素がリーダーモードで悪さをしているみたいだったので
`<time>` => `<span>` に変更した。

<img width="480" alt="Screen Shot 2021-07-03 at 18 29 25" src="https://user-images.githubusercontent.com/1996642/124351126-88b5f100-dc33-11eb-85c2-43d7b1f9a201.png">
<img width="480" alt="Screen Shot 2021-07-03 at 18 29 23" src="https://user-images.githubusercontent.com/1996642/124351125-86ec2d80-dc33-11eb-899f-1b90242a1411.png">

日付の正確性をそこまで求めてないのと、マークアップで不具合がでるよりも文章の方で伝えるようが良いと思い変更