### PR TITLE
Delete redundant role

### DIFF
--- a/components/about-sections/ComponentOriented.vue
+++ b/components/about-sections/ComponentOriented.vue
@@ -36,8 +36,8 @@ export default {
   data() {
     return {
       slide: `
-<ul role="list">
-  <li role="listitem" v-for="list in listItem" :key="list.index">
+<ul>
+  <li v-for="list in listItem" :key="list.index">
     <template v-if="list.datetime">
       <span class="time">{{
         dateStirngReplace(list.datetime)

--- a/components/about-sections/DoNotOverDesign.vue
+++ b/components/about-sections/DoNotOverDesign.vue
@@ -8,8 +8,8 @@
     </h3>
     <p>{{ $t("aboutPage.overdesign.desc01") }}</p>
     <p>{{ $t("aboutPage.overdesign.desc02") }}</p>
-    <ul role="list">
-      <li role="listitem">
+    <ul>
+      <li>
         <a
           href="//motherfuckingwebsite.com/"
           target="_blank"

--- a/components/about-sections/Markup.vue
+++ b/components/about-sections/Markup.vue
@@ -9,8 +9,8 @@
         <highlightjs lang="html" :code="waiAria" />
         <figcaption>
           <p>{{ $t("aboutPage.markup.caption") }}</p>
-          <ul role="list">
-            <li role="listitem">
+          <ul>
+            <li>
               <a
                 href="https://www.w3.org/TR/wai-aria-practices-1.1/#naming_role_guidance"
                 target="_blank"

--- a/components/about-sections/TechStack.vue
+++ b/components/about-sections/TechStack.vue
@@ -3,28 +3,28 @@
     <h3 id="about:tech-stack_heading">
       {{ $t("heading.techStack") }}
     </h3>
-    <ul role="list" lang="en">
-      <li role="listitem">
+    <ul lang="en">
+      <li>
         Nuxt.js
-        <ul role="list">
-          <li role="listitem">@nuxt/content</li>
-          <li role="listitem">@nuxtjs/axios</li>
-          <li role="listitem">@nuxtjs/dotenv</li>
-          <li role="listitem">@nuxtjs/pwa</li>
-          <li role="listitem">nuxt-i18n</li>
+        <ul>
+          <li>@nuxt/content</li>
+          <li>@nuxtjs/axios</li>
+          <li>@nuxtjs/dotenv</li>
+          <li>@nuxtjs/pwa</li>
+          <li>nuxt-i18n</li>
         </ul>
       </li>
-      <li role="listitem">Vuex （Store）</li>
-      <li role="listitem">
+      <li>Vuex （Store）</li>
+      <li>
         eslint
-        <ul role="list">
-          <li role="listitem">eslint-plugin-prettier</li>
-          <li role="listitem">eslint-plugin-vue</li>
-          <li role="listitem">eslint-plugin-vuejs-accessibility</li>
+        <ul>
+          <li>eslint-plugin-prettier</li>
+          <li>eslint-plugin-vue</li>
+          <li>eslint-plugin-vuejs-accessibility</li>
         </ul>
       </li>
-      <li role="listitem">modern-normalize</li>
-      <li role="listitem">Google Fonts</li>
+      <li>modern-normalize</li>
+      <li>Google Fonts</li>
     </ul>
   </section>
 </template>

--- a/components/global/DonateComponent.vue
+++ b/components/global/DonateComponent.vue
@@ -6,9 +6,9 @@
     <p>
       {{ $t("donate.desc01") }}
     </p>
-    <ul role="list">
+    <ul>
       <template v-for="donateLink in donateLinkList">
-        <li role="listitem" :key="donateLink.title">
+        <li :key="donateLink.title">
           <a
             :href="donateLink.url"
             target="_blank"

--- a/components/global/FeedbackList.vue
+++ b/components/global/FeedbackList.vue
@@ -1,14 +1,14 @@
 <template>
   <details>
     <summary>{{ $t("details.summary_feedback") }}</summary>
-    <ul role="list">
-      <li role="listitem">
+    <ul>
+      <li>
         <a :href="gitHubLink" target="_blank" rel="noopener">
           {{ this.$t("feedback.github.title") }}
           <open-new-icon />
         </a>
       </li>
-      <li role="listitem">
+      <li>
         <a :href="twitterLink" target="_blank" rel="noopener">
           {{ this.$t("feedback.twitter.title") }}
           <open-new-icon />

--- a/components/global/LocalSwitch.vue
+++ b/components/global/LocalSwitch.vue
@@ -1,8 +1,8 @@
 <template>
   <nav :aria-label="$t('multilingual')">
     <h2 id="local-switching">{{ $t("multilingual") }}</h2>
-    <ul role="list">
-      <li role="listitem" v-for="locale in $i18n.locales" :key="locale.code">
+    <ul>
+      <li v-for="locale in $i18n.locales" :key="locale.code">
         <nuxt-link :lang="locale.code" :to="switchLocalePath(locale.code)">{{
           locale.name
         }}</nuxt-link>

--- a/components/global/Navigation.vue
+++ b/components/global/Navigation.vue
@@ -1,12 +1,12 @@
 <template>
   <nav aria-label="global-navigation">
-    <ul class="global" role="list">
-      <li role="listitem">
+    <ul class="global">
+      <li>
         <nuxt-link :to="localePath({ name: 'index' })">{{
           $t("home.title")
         }}</nuxt-link>
       </li>
-      <li role="listitem">
+      <li>
         <nuxt-link :to="localePath({ name: 'about' })">{{
           $t("aboutPage.title")
         }}</nuxt-link>

--- a/components/global/SlideList.vue
+++ b/components/global/SlideList.vue
@@ -1,6 +1,6 @@
 <template>
-  <ul role="list">
-    <li role="listitem" v-for="list in listItem" :key="list.index">
+  <ul>
+    <li v-for="list in listItem" :key="list.index">
       <template v-if="list.datetime">
         <span class="time">{{ dateStirngReplace(list.datetime) }}</span>
         -

--- a/components/products/AccessibilityBeginner.vue
+++ b/components/products/AccessibilityBeginner.vue
@@ -34,11 +34,8 @@
     <h4 id="related:web-accessibility-for-beginner_heading">
       {{ $t("heading.relatedList") }}
     </h4>
-    <ul
-      role="list"
-      aria-labelledby="related:web-accessibility-for-beginner_heading"
-    >
-      <li role="listitem">
+    <ul aria-labelledby="related:web-accessibility-for-beginner_heading">
+      <li>
         <a
           href="https://techbookfest.org/event/tbf05/circle/41130001"
           target="_blank"
@@ -48,7 +45,7 @@
           <open-new-icon />
         </a>
       </li>
-      <li role="listitem">
+      <li>
         <a
           href="https://booth.pm/ja/items/1044446"
           target="_blank"
@@ -58,7 +55,7 @@
           <shopping-icon />
         </a>
       </li>
-      <li role="listitem">
+      <li>
         <a
           href="https://note.mu/yamanoku/n/n3487a344ff84"
           target="_blank"

--- a/components/products/OclockApp.vue
+++ b/components/products/OclockApp.vue
@@ -24,14 +24,14 @@
       </figcaption>
     </figure>
     <h4 id="related:oclock-app_heading">{{ $t("heading.relatedList") }}</h4>
-    <ul role="list" aria-labelledby="related:oclock-app_heading">
-      <li role="listitem">
+    <ul aria-labelledby="related:oclock-app_heading">
+      <li>
         <a href="https://yamanoku.net/oclock/" target="_blank" rel="noopener">
           {{ $t("product.oclock-app.title") }}
           <open-new-icon />
         </a>
       </li>
-      <li role="listitem">
+      <li>
         <a
           href="https://zenn.dev/yamanoku/scraps/bb713d47a45a55/"
           target="_blank"
@@ -43,10 +43,10 @@
       </li>
     </ul>
     <h4 id="teck-stack:oclock-app_heading">{{ $t("heading.techStack") }}</h4>
-    <ul role="list" aria-labelledby="teck-stack:oclock-app_heading">
-      <li role="listitem">Svelte</li>
-      <li role="listitem">Custom Elements</li>
-      <li role="listitem">WAI-ARIA</li>
+    <ul aria-labelledby="teck-stack:oclock-app_heading">
+      <li>Svelte</li>
+      <li>Custom Elements</li>
+      <li>WAI-ARIA</li>
     </ul>
   </article>
 </template>

--- a/components/products/Reading.vue
+++ b/components/products/Reading.vue
@@ -19,14 +19,14 @@
       </figcaption>
     </figure>
     <h4 id="related:reading_heading">{{ $t("heading.relatedList") }}</h4>
-    <ul role="list" aria-labelledby="related:reading_heading">
-      <li role="listitem">
+    <ul aria-labelledby="related:reading_heading">
+      <li>
         <a href="https://reading.yamanoku.net" target="_blank" rel="noopener">
           {{ $t("product.reading") }}
           <open-new-icon />
         </a>
       </li>
-      <li role="listitem">
+      <li>
         <a
           href="https://scrapbox.io/yamanoku/Reading%E2%80%A6#5b1f8344c2cd3f000095e9c0"
           target="_blank"
@@ -36,7 +36,7 @@
           <open-new-icon />
         </a>
       </li>
-      <li role="listitem">
+      <li>
         <a
           href="https://www.figma.com/file/IHsJKRaJXepsqcbX91iQ6YNV/Reading...-Components?node-id=44%3A23"
           target="_blank"
@@ -48,16 +48,16 @@
       </li>
     </ul>
     <h4 id="teck-stack:reading_heading">{{ $t("heading.techStack") }}</h4>
-    <ul role="list" aria-labelledby="teck-stack:reading_heading">
-      <li role="listitem">Nuxt.js</li>
-      <li role="listitem">Nuxt PWA</li>
-      <li role="listitem">vue-paginate</li>
-      <li role="listitem">axios</li>
-      <li role="listitem">modern-normalize</li>
-      <li role="listitem">AWS API Gateway</li>
-      <li role="listitem">AWS Lambda Function</li>
-      <li role="listitem">Netlify</li>
-      <li role="listitem">CircleCI</li>
+    <ul aria-labelledby="teck-stack:reading_heading">
+      <li>Nuxt.js</li>
+      <li>Nuxt PWA</li>
+      <li>vue-paginate</li>
+      <li>axios</li>
+      <li>modern-normalize</li>
+      <li>AWS API Gateway</li>
+      <li>AWS Lambda Function</li>
+      <li>Netlify</li>
+      <li>CircleCI</li>
     </ul>
   </article>
 </template>

--- a/components/products/VuePortfolio.vue
+++ b/components/products/VuePortfolio.vue
@@ -27,8 +27,8 @@
       </figcaption>
     </figure>
     <h4 id="related:vue-portfolio_heading">{{ $t("heading.relatedList") }}</h4>
-    <ul role="list" aria-labelledby="related:vue-portfolio_heading">
-      <li role="listitem">
+    <ul aria-labelledby="related:vue-portfolio_heading">
+      <li>
         <a
           href="https://vue-portfolio.yamanoku.net/"
           target="_blank"
@@ -38,7 +38,7 @@
           <open-new-icon />
         </a>
       </li>
-      <li role="listitem">
+      <li>
         <a
           href="https://www.figma.com/file/4yN9uOXGISbSTocH23EX8O/vue_portfolio_template-Style?node-id=0%3A1"
           target="_blank"
@@ -50,13 +50,13 @@
       </li>
     </ul>
     <h4 id="tech-stack:vue-portfolio_heading">{{ $t("heading.techStack") }}</h4>
-    <ul role="list" aria-labelledby="tech-stack:vue-portfolio_heading">
-      <li role="listitem">Vue.js</li>
-      <li role="listitem">vue-cli</li>
-      <li role="listitem">vue-router</li>
-      <li role="listitem">webpack</li>
-      <li role="listitem">PostCSS</li>
-      <li role="listitem">Netlify</li>
+    <ul aria-labelledby="tech-stack:vue-portfolio_heading">
+      <li>Vue.js</li>
+      <li>vue-cli</li>
+      <li>vue-router</li>
+      <li>webpack</li>
+      <li>PostCSS</li>
+      <li>Netlify</li>
     </ul>
   </article>
 </template>

--- a/components/sections/BasicInfo.vue
+++ b/components/sections/BasicInfo.vue
@@ -8,10 +8,10 @@
     </template>
     <template v-else>Okuto Oyama. {{ $t("info.caption") }}</template>
     <h3 id="job_heading">{{ $t("heading.job") }}</h3>
-    <ul role="list" aria-labelledby="job_heading">
-      <li role="listitem">{{ $t("jobs.job01") }}</li>
-      <li role="listitem">{{ $t("jobs.job02") }}</li>
-      <li role="listitem">{{ $t("jobs.job03") }}</li>
+    <ul aria-labelledby="job_heading">
+      <li>{{ $t("jobs.job01") }}</li>
+      <li>{{ $t("jobs.job02") }}</li>
+      <li>{{ $t("jobs.job03") }}</li>
     </ul>
   </section>
 </template>

--- a/components/sections/CareerInfo.vue
+++ b/components/sections/CareerInfo.vue
@@ -7,8 +7,8 @@
     <p>{{ $t("career.desc02") }}</p>
     <p>{{ $t("career.desc03") }}</p>
     <h3 id="related:career_heading">{{ $t("heading.relatedList") }}</h3>
-    <ul role="list" aria-labelledby="related:career_heading">
-      <li role="listitem">
+    <ul aria-labelledby="related:career_heading">
+      <li>
         <a
           href="https://github.com/yamanoku/Curriculum-Vitae/blob/master/README.md"
           target="_blank"
@@ -18,7 +18,7 @@
           <github-icon />
         </a>
       </li>
-      <li role="listitem">
+      <li>
         <a
           href="https://scrapbox.io/yamanoku/%E7%B5%8C%E9%A8%93%E3%81%AE%E3%81%82%E3%82%8B%E6%8A%80%E8%A1%93"
           target="_blank"
@@ -28,7 +28,7 @@
           <open-new-icon />
         </a>
       </li>
-      <li role="listitem">
+      <li>
         <a
           href="https://www.wantedly.com/id/yamanoku"
           target="_blank"
@@ -38,7 +38,7 @@
           <open-new-icon />
         </a>
       </li>
-      <li role="listitem">
+      <li>
         <a
           href="https://lapras.com/public/ZQJMZYO"
           target="_blank"
@@ -48,7 +48,7 @@
           <open-new-icon />
         </a>
       </li>
-      <li role="listitem">
+      <li>
         <a
           href="https://youtrust.jp/users/57ea573ffca186c3b339f1739915f40b"
           target="_blank"

--- a/components/sections/Sns.vue
+++ b/components/sections/Sns.vue
@@ -3,36 +3,36 @@
     <h2 id="sns_heading">
       {{ $t("heading.sns") }}
     </h2>
-    <ul role="list">
-      <li role="listitem">
+    <ul>
+      <li>
         <a href="https://twitter.com/yamanoku" target="_blank" rel="noopener"
           >{{ $t("sns.twitter") }}<open-new-icon
         /></a>
       </li>
-      <li role="listitem">
+      <li>
         <a href="https://github.com/yamanoku" target="_blank" rel="noopener"
           >{{ $t("sns.github") }}<open-new-icon
         /></a>
       </li>
-      <li role="listitem">
+      <li>
         <a href="https://scrapbox.io/yamanoku/" target="_blank" rel="noopener"
           >{{ $t("sns.scrapbox") }}<open-new-icon
         /></a>
       </li>
-      <li role="listitem">
+      <li>
         <a href="https://facebook.com/yamanoku" target="_blank" rel="noopener"
           >{{ $t("sns.facebook") }}<open-new-icon
         /></a>
       </li>
-      <li role="listitem">
+      <li>
         {{ $t("sns.tumblr.text") }}
-        <ul role="list">
-          <li role="listitem">
+        <ul>
+          <li>
             <a href="https://yamanoku.tumblr.com" target="_blank" rel="noopener"
               >{{ $t("sns.tumblr.tumblog") }}<open-new-icon
             /></a>
           </li>
-          <li role="listitem">
+          <li>
             <a
               href="https://yamagraph.tumblr.com"
               target="_blank"

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -1,5 +1,5 @@
 <template>
-  <main role="main" id="main">
+  <main id="main">
     <template v-if="error.statusCode === 404">
       <h1>404</h1>
       <p lang="ja">

--- a/pages/404.vue
+++ b/pages/404.vue
@@ -1,5 +1,5 @@
 <template>
-  <main role="main" id="main">
+  <main id="main">
     <h1>404</h1>
     <p lang="ja">
       申し訳ありません。お探しのページが見つかりませんでした。<br />

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -1,5 +1,5 @@
 <template>
-  <main role="main" id="main">
+  <main id="main">
     <h1 id="about_heading">{{ $t("aboutPage.title") }}</h1>
     <p>{{ $t("aboutPage.description") }}</p>
     <section class="toc" id="about:toc" aria-labelledby="about:toc_heading">

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -4,61 +4,61 @@
     <p>{{ $t("aboutPage.description") }}</p>
     <section class="toc" id="about:toc" aria-labelledby="about:toc_heading">
       <h2 id="about:toc_heading">{{ $t("aboutPage.heading.toc") }}</h2>
-      <ul role="list">
-        <li role="listitem">
+      <ul>
+        <li>
           <a href="#about:implementation">{{
             $t("aboutPage.heading.implementation")
           }}</a>
-          <ul role="list">
-            <li role="listitem">
+          <ul>
+            <li>
               <a href="#about:tech-stack">{{ $t("heading.techStack") }}</a>
             </li>
-            <li role="listitem">
+            <li>
               <a href="#about:markup">{{
                 $t("aboutPage.subHeading.markup")
               }}</a>
             </li>
-            <li role="listitem">
+            <li>
               <a href="#about:component-oriented">{{
                 $t("aboutPage.subHeading.components")
               }}</a>
             </li>
-            <li role="listitem">
+            <li>
               <a href="#about:progressive-web-application">{{
                 $t("aboutPage.subHeading.pwa")
               }}</a>
             </li>
-            <li role="listitem">
+            <li>
               <a href="#about:internationalization">{{
                 $t("aboutPage.subHeading.i18n")
               }}</a>
             </li>
           </ul>
         </li>
-        <li role="listitem">
+        <li>
           <a href="#about:design">{{ $t("aboutPage.heading.design") }}</a>
-          <ul role="list">
-            <li role="listitem">
+          <ul>
+            <li>
               <a href="#about:do-not-over-design">{{
                 $t("aboutPage.subHeading.overdesign")
               }}</a>
             </li>
-            <li role="listitem">
+            <li>
               <a href="#about:font-size">{{
                 $t("aboutPage.subHeading.fontSize")
               }}</a>
             </li>
-            <li role="listitem">
+            <li>
               <a href="#about:color-contrast">{{
                 $t("aboutPage.subHeading.contrast")
               }}</a>
             </li>
-            <li role="listitem">
+            <li>
               <a href="#about:max-width">{{
                 $t("aboutPage.subHeading.maxWidth")
               }}</a>
             </li>
-            <li role="listitem">
+            <li>
               <a href="#about:vertical-rhythm">{{
                 $t("aboutPage.subHeading.verticalRhythm")
               }}</a>

--- a/pages/archive/_slug.vue
+++ b/pages/archive/_slug.vue
@@ -1,5 +1,5 @@
 <template>
-  <main role="main" id="main">
+  <main id="main">
     <article>
       <h1>{{ page.title }}</h1>
       <div class="article-header">

--- a/pages/archive/index.vue
+++ b/pages/archive/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <main role="main" id="main">
+  <main id="main">
     <h1>{{ $t("archivePage.title") }}</h1>
     <p>
       {{ $t("archivePage.desc01") }}

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <main role="main" id="main">
+  <main id="main">
     <h1>yamanoku.net</h1>
     <SectionsBasicInfo />
     <SectionsCareerInfo />

--- a/pages/privacy.vue
+++ b/pages/privacy.vue
@@ -9,8 +9,8 @@
       <p>{{ $t("privacyPage.analytics.desc02") }}</p>
       <p>{{ $t("privacyPage.analytics.desc03") }}</p>
       <h3 id="related:analytics_heading">{{ $t("heading.relatedList") }}</h3>
-      <ul role="list" aria-labelledby="related:analytics_heading">
-        <li role="listitem">
+      <ul aria-labelledby="related:analytics_heading">
+        <li>
           <a
             :href="$t('privacyPage.analytics.link01.url')"
             target="_blank"
@@ -18,7 +18,7 @@
             >{{ $t("privacyPage.analytics.link01.title") }}<open-new-icon
           /></a>
         </li>
-        <li role="listitem">
+        <li>
           <a
             :href="$t('privacyPage.analytics.link02.url')"
             target="_blank"

--- a/pages/privacy.vue
+++ b/pages/privacy.vue
@@ -1,5 +1,5 @@
 <template>
-  <main role="main" id="main">
+  <main id="main">
     <h1 id="privacy-policy_heading">{{ $t("privacyPage.title") }}</h1>
     <section id="privacy:analytics" aria-labelledby="privacy:analytics_heading">
       <h2 id="privacy:analytics_heading">

--- a/pages/vue-a11y.vue
+++ b/pages/vue-a11y.vue
@@ -1,5 +1,5 @@
 <template>
-  <main role="main" id="main">
+  <main id="main">
     <vuejs-accessibility-sections-title />
     <global-local-switch />
     <vuejs-accessibility-sections-bio />


### PR DESCRIPTION
重複していたroleを削除。

- `role="list"` や `role="listitem"` は iOS Safari でのバグ（[参考URL](https://gerardkcohen.me/writing/2017/voiceover-list-style-type.html)）
- `role="main"` は PC Talker への配慮（[参考URL](https://docs.google.com/presentation/d/1Gcny5O0jrFbRVfjJWTiRfFkk3EMCLwiS-kqwj_JTCUM/htmlpresent)）

いずれもスクリーンリーダーユーザーへの配慮ではあったが、[Nu Html Checker](https://validator.w3.org/nu/) での重複指摘や
[scott ohara氏のブログ](https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html)でもあるように `Perform testing with real people!` なきアクセシビリティの配慮もよくないと感じてきたため、削除することにした。