### PR TITLE
fix: codesandbox url

### DIFF
--- a/components/vuejs-accessibility-2019-sections/AccessibleNotes.vue
+++ b/components/vuejs-accessibility-2019-sections/AccessibleNotes.vue
@@ -54,7 +54,7 @@
       {{ $t("vueA11yPage2019.a11yNote.desc07") }}
     </p>
     <a
-      href="https://codesandbox.io/s/vue-accessible-modal-9m474]"
+      href="https://codesandbox.io/s/vue-accessible-modal-9m474"
       target="_blank"
       rel="noopener"
       lang="en"


### PR DESCRIPTION
URL末尾に`]`が含まれて正しいリンクになっていなかった

## 経緯
Nu Html Checker にて発見
[![Image from Gyazo](https://i.gyazo.com/9ceb828062b6033243bfc37189dce216.png)](https://gyazo.com/9ceb828062b6033243bfc37189dce216)