### PR TITLE
renovate ignore update highlight.js

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,11 @@
   "schedule": ["after 10pm and before 6am on every weekday"],
   "assignees": [
     "yamanoku"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["highlight.js"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
nuxt の状態で v11 に上げるのを断念