### PR TITLE
update: basic info markup

### DIFF
--- a/assets/locales/en.yaml
+++ b/assets/locales/en.yaml
@@ -2,7 +2,26 @@ jobs:
   frontendDesigner: "FrontEnd Designer"
   uiDesigner: "UI Designer"
 info:
-  caption: "I'm active on the Internet under the name of Oyama-Michinoku, yamanoku. My birthday is October 30, 1989. I was born in Noshiro City, Akita Prefecture. I'm male. Currently, I lives in Nagareyama City, Chiba Prefecture. One daughter's father and owner of three cats and one dog."
+  realName:
+    key: "Real name"
+  hundleName:
+    key: "Hundle name"
+    value: "Oyama Michinoku, yamanoku"
+  birthday:
+    key: "Birthday"
+    value: "October 30, 1989"
+  sex:
+    key: "Sex"
+    value: "Male"
+  birthplace:
+    key: "Birthplace"
+    value: "Noshiro, Akita"
+  location:
+    key: "Location"
+    value: "Nagareyama, Chiba"
+  family:
+    key: "Family Composition"
+    value: "Wife, daughter, 3 cats and a large dog"
 career:
   wantedly: "Wantedly"
   lapras: "LAPRAS"

--- a/assets/locales/ja.yaml
+++ b/assets/locales/ja.yaml
@@ -2,7 +2,26 @@ jobs:
   frontendDesigner: "フロントエンドデザイナー"
   uiDesigner: "UIデザイナー"
 info:
-  caption: "ネット上では、おおやまみちのく、yamanokuと名乗って活動しています。誕生日は1989年10月30日。秋田県能代市生まれ。性別は男性。現在千葉県流山市在住。一児（娘）の父と3匹の猫と1匹の犬の飼い主。"
+  realName:
+    key: "本名"
+  hundleName:
+    key: "ハンドルネーム"
+    value: "おおやまみちのく、yamanoku"
+  birthday:
+    key: "誕生日"
+    value: "1989年10月30日"
+  sex:
+    key: "性別"
+    value: "男性"
+  birthplace:
+    key: "出身"
+    value: "秋田県能代市"
+  location:
+    key: "所在"
+    value: "千葉県流山市"
+  family:
+    key: "家族構成"
+    value: "妻、娘、猫（3匹）、大型犬（1頭）"
 career:
   wantedly: "Wantedly"
   lapras: "LAPRAS"

--- a/components/pages/index/sections/BasicInfo.vue
+++ b/components/pages/index/sections/BasicInfo.vue
@@ -5,12 +5,33 @@
       :heading-level="2"
       :heading-text="$t('heading.basic')"
     />
-    <template v-if="this.$i18n.locale === 'ja'">
-      大山奥人
-      <small>（おおやまおくと）</small>
-      。{{ $t("info.caption") }}
-    </template>
-    <template v-else>Okuto Oyama. {{ $t("info.caption") }}</template>
+    <dl>
+      <dt>{{ this.$t("info.realName.key") }}</dt>
+      <dd>
+        <template v-if="this.$i18n.locale === 'ja'">
+          <ruby
+            >大<rp>(</rp><rt>おお</rt><rp>)</rp>山<rp>(</rp><rt>やま</rt
+            ><rp>)</rp></ruby
+          ><ruby
+            >奥<rp>(</rp><rt>おく</rt><rp>)</rp>人<rp>(</rp><rt>と</rt
+            ><rp>)</rp></ruby
+          >
+        </template>
+        <template v-else>Okuto Oyama</template>
+      </dd>
+      <dt>{{ this.$t("info.hundleName.key") }}</dt>
+      <dd>{{ this.$t("info.hundleName.value") }}</dd>
+      <dt>{{ this.$t("info.birthday.key") }}</dt>
+      <dd>{{ this.$t("info.birthday.value") }}</dd>
+      <dt>{{ this.$t("info.sex.key") }}</dt>
+      <dd>{{ this.$t("info.sex.value") }}</dd>
+      <dt>{{ this.$t("info.birthplace.key") }}</dt>
+      <dd>{{ this.$t("info.birthplace.value") }}</dd>
+      <dt>{{ this.$t("info.location.key") }}</dt>
+      <dd>{{ this.$t("info.location.value") }}</dd>
+      <dt>{{ this.$t("info.family.key") }}</dt>
+      <dd>{{ this.$t("info.family.value") }}</dd>
+    </dl>
   </section>
 </template>
 

--- a/packages/yama-normalize/demo/index.html
+++ b/packages/yama-normalize/demo/index.html
@@ -64,6 +64,14 @@
           </li>
           <li>first</li>
         </ol>
+        <dl>
+          <dt>name 01</dt>
+          <dd>value 01</dd>
+          <dt>name 02</dt>
+          <dd>value 02</dd>
+          <dt>name 03</dt>
+          <dd>value 03</dd>
+        </dl>
         <details>
           <summary>details + summary</summary>
           summary style add <code>cursor: pointer;</code>

--- a/packages/yama-normalize/yama-normalize.css
+++ b/packages/yama-normalize/yama-normalize.css
@@ -75,14 +75,14 @@ html {
 html[lang="ja"] {
   font-kerning: none;
 }
+body {
+  margin: 0;
+}
 html:not([lang="ja"]) body {
   hyphens: auto;
 }
 html[lang="ja"] body {
   line-break: loose;
-}
-body {
-  margin: 0;
 }
 a {
   color: var(--y-link-color);
@@ -208,6 +208,17 @@ ul:not([class]) li::before {
   margin: 9px 0 0;
   position: absolute;
   left: 0;
+}
+dl {
+  margin: var(--y-rhythm-3) 0;
+  line-height: 1;
+}
+dt, dd {
+  line-height: var(--y-rhythm-3);
+  font-size: 1rem;
+}
+dd {
+  margin-left: var(--y-rhythm-4);
 }
 details > summary {
   margin: var(--y-rhythm-3) 0;


### PR DESCRIPTION
段落として書かれているものを説明リストとして扱うようにアップデート

<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td><img src="https://user-images.githubusercontent.com/1996642/200168118-36815800-1238-4b93-a0c1-23cd554ff1c1.png" alt="p タグでの表現">
	<td><img src="https://user-images.githubusercontent.com/1996642/200168117-0ba749f7-816a-45a9-8b8f-c3f7d4c841d1.png" alt="dl dt dd タグでの表現">
</table>
