### PR TITLE
マージされたときのみ deploy フローを動かすようにする

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    if: github.event.pull_request.merged == true
     strategy:
       matrix:
         node-version: [18.x]


### PR DESCRIPTION
マージではなくクローズした場合もデプロイが動いてしまうので制御する
ref: [Github Actions にて pull request で main branch に merge されたときに処理を行いたい時](https://zenn.dev/sunecosuri/articles/59a46c6e5a029c)