### PR TITLE
add: dependencies label

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
     "config:base",
     "group:monorepos"
   ],
+  "labels": ["dependencies"],
   "dependencyDashboard": false,
   "automerge": true,
   "major": {


### PR DESCRIPTION
renovate で `dependencies` ラベルを自動で付与するようにする

#1106 のためにつけたい