### PR TITLE
markuplint の実行において ts-node が存在しないためエラーが発生するものの暫定対策

### DIFF
--- a/.github/workflows/markuplint.yml
+++ b/.github/workflows/markuplint.yml
@@ -26,6 +26,7 @@ jobs:
       run: |
         yarn install
         yarn build
+        rm -rf node_modules
         yarn markuplint
       env:
         CI: true

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "yarn eslint && yarn markuplint",
     "eslint": "eslint --ext .ts,.astro --ignore-path .gitignore .",
     "eslint:fix": "eslint --fix --ext .ts,.astro --ignore-path .gitignore .",
-    "markuplint": "markuplint 'dist/**/*.html'",
+    "markuplint": "npx markuplint 'dist/**/*.html'",
     "prettier": "yarn prettier:ts && yarn prettier:astro",
     "prettier:ts": "prettier --check 'src/**/*.ts'",
     "prettier:astro": "prettier --check 'src/**/*.astro'",


### PR DESCRIPTION
markuplint@3.12.0 のアップデート以後、CI・ローカル上でエラーが発生するようになった（[エラーログ](https://github.com/yamanoku/yamanoku.github.io/actions/runs/5627730204/job/15250713977)）。

```shell
$ markuplint 'dist/**/*.html'
node:internal/modules/cjs/loader:1080
  throw err;
  ^

Error: Cannot find module 'ts-node'
Require stack:
- /home/runner/work/yamanoku.github.io/yamanoku.github.io/node_modules/cosmiconfig-typescript-loader/dist/cjs/index.js
- /home/runner/work/yamanoku.github.io/yamanoku.github.io/node_modules/@markuplint/file-resolver/lib/cosmiconfig.js
- /home/runner/work/yamanoku.github.io/yamanoku.github.io/node_modules/@markuplint/file-resolver/lib/config-provider.js
- /home/runner/work/yamanoku.github.io/yamanoku.github.io/node_modules/@markuplint/file-resolver/lib/index.js
- /home/runner/work/yamanoku.github.io/yamanoku.github.io/node_modules/markuplint/lib/cli/command.js
- /home/runner/work/yamanoku.github.io/yamanoku.github.io/node_modules/markuplint/lib/cli/index.js
- /home/runner/work/yamanoku.github.io/yamanoku.github.io/node_modules/markuplint/bin/markuplint
    at Module._resolveFilename (node:internal/modules/cjs/loader:1077:15)
    at Module._load (node:internal/modules/cjs/loader:922:27)
    at Module.require (node:internal/modules/cjs/loader:1143:19)
    at require (node:internal/modules/cjs/helpers:110:18)
    at Object.<anonymous> (/home/runner/work/yamanoku.github.io/yamanoku.github.io/node_modules/cosmiconfig-typescript-loader/dist/cjs/index.js:28:22)
    at Module._compile (node:internal/modules/cjs/loader:12[56](https://github.com/yamanoku/yamanoku.github.io/actions/runs/5627761144/job/15250794001#step:4:57):14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Module._load (node:internal/modules/cjs/loader:9[60](https://github.com/yamanoku/yamanoku.github.io/actions/runs/5627761144/job/15250794001#step:4:61):12)
    at Module.require (node:internal/modules/cjs/loader:1143:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/home/runner/work/yamanoku.github.io/yamanoku.github.io/node_modules/cosmiconfig-typescript-loader/dist/cjs/index.js',
    '/home/runner/work/yamanoku.github.io/yamanoku.github.io/node_modules/@markuplint/file-resolver/lib/cosmiconfig.js',
    '/home/runner/work/yamanoku.github.io/yamanoku.github.io/node_modules/@markuplint/file-resolver/lib/config-provider.js',
    '/home/runner/work/yamanoku.github.io/yamanoku.github.io/node_modules/@markuplint/file-resolver/lib/index.js',
    '/home/runner/work/yamanoku.github.io/yamanoku.github.io/node_modules/markuplint/lib/cli/command.js',
    '/home/runner/work/yamanoku.github.io/yamanoku.github.io/node_modules/markuplint/lib/cli/index.js',
    '/home/runner/work/yamanoku.github.io/yamanoku.github.io/node_modules/markuplint/bin/markuplint'
  ]
}
```

事象は [Cannot find module 'ts-node' · Issue #1401 · lingui/js-lingui](https://togithub.com/lingui/js-lingui/issues/1401) と同じ様になっており、依存元の [cosmiconfig-typescript-loader](https://github.com/Codex-/cosmiconfig-typescript-loader) 側の peerDependencies が起因している模様。

- [Lazy loading for ts-node + optional peer-dependecies · Issue #79 · Codex-/cosmiconfig-typescript-loader](https://togithub.com/Codex-/cosmiconfig-typescript-loader/issues/79)
- [Lazy loading of ts-node. Fixes #79 by Codex- · Pull Request #84 · Codex-/cosmiconfig-typescript-loader](https://togithub.com/Codex-/cosmiconfig-typescript-loader/pull/84)

上記が解消されるまで、表題通りの対応を実施。