### PR TITLE
SNSリンクの整理＆日報に関するリンク先を作成

### DIFF
--- a/src/components/page-index/sections/DailyJournalSection.astro
+++ b/src/components/page-index/sections/DailyJournalSection.astro
@@ -1,0 +1,28 @@
+---
+import GlobalListComponent from "../../global/GlobalListComponent.astro";
+import { getLanguageFromURL, useTranslations } from "../../../i18n/util";
+const lang = getLanguageFromURL(Astro.url.pathname);
+const t = useTranslations(Astro);
+---
+
+<section id="daily-journal" aria-labelledby="daily-journal_heading">
+  <h2 id="daily-journal_heading">{t("heading.daily-journal")}</h2>
+  <slot />
+  {lang === "en" && <em>Sorry, Japanese text only</em>}
+  <GlobalListComponent
+    list={[
+      {
+        title: "nippo-2023",
+        url: "https://scrapbox.io/yamanoku/nippo-2023"
+      },
+      {
+        title: "nippo-2022",
+        url: "https://scrapbox.io/yamanoku/nippo-2022"
+      },
+      {
+        title: "nippo-2021",
+        url: "https://scrapbox.io/yamanoku/nippo-2021"
+      }
+    ]}
+  />
+</section>

--- a/src/components/page-index/sections/SocialNetworkServicesSection.astro
+++ b/src/components/page-index/sections/SocialNetworkServicesSection.astro
@@ -20,14 +20,6 @@ const t = useTranslations(Astro);
         url: "https://github.com/yamanoku"
       },
       {
-        title: "Scrapbox",
-        url: "https://scrapbox.io/yamanoku/"
-      },
-      {
-        title: "Zenn",
-        url: "https://zenn.dev/yamanoku"
-      },
-      {
         title: "Facebook",
         url: "https://facebook.com/okutooyama"
       },

--- a/src/i18n/en/dictionary.ts
+++ b/src/i18n/en/dictionary.ts
@@ -16,6 +16,7 @@ export default Dictionary({
   "heading.donate": "Donate & Sponsor",
   "heading.contact": "Contact",
   "heading.open-source-activity": "Open Source Activity",
+  "heading.daily-journal": "Daily journal",
 
   // basic Info
   "info.real-name": "Real name",

--- a/src/i18n/ja/dictionary.ts
+++ b/src/i18n/ja/dictionary.ts
@@ -14,6 +14,7 @@ export default {
   "heading.donate": "寄付・支援",
   "heading.contact": "連絡先",
   "heading.open-source-activity": "オープンソース活動",
+  "heading.daily-journal": "日報",
 
   // 基本情報
   "info.real-name": "本名",

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -4,6 +4,7 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 import BasicInfoSection from "../../components/page-index/sections/BasicInfoSection.astro";
 import CareerInfoSection from "../../components/page-index/sections/CareerInfoSection.astro";
 import OpenSourceActivitySection from "../../components/page-index/sections/OpenSourceActivitySection.astro";
+import DailyJournalSection from "../../components/page-index/sections/DailyJournalSection.astro";
 import PresentationsSection from "../../components/page-index/sections/PresentationsSection.astro";
 import SocialNetworkServicesSection from "../../components/page-index/sections/SocialNetworkServicesSection.astro";
 import AddressSection from "../../components/page-index/sections/AddressSection.astro";
@@ -44,6 +45,13 @@ import AddressSection from "../../components/page-index/sections/AddressSection.
       </p>
     </CareerInfoSection>
     <OpenSourceActivitySection />
+    <DailyJournalSection>
+      <p>
+        I utilize <a href="https://scrapbox.io/">Scrapbox</a> to compile daily
+        events and interesting news in the form of a journal. Rather than
+        updating daily, I post whenever inspiration strikes.
+      </p>
+    </DailyJournalSection>
     <PresentationsSection />
     <SocialNetworkServicesSection />
     <AddressSection />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,6 +4,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 import BasicInfoSection from "../components/page-index/sections/BasicInfoSection.astro";
 import CareerInfoSection from "../components/page-index/sections/CareerInfoSection.astro";
 import OpenSourceActivitySection from "../components/page-index/sections/OpenSourceActivitySection.astro";
+import DailyJournalSection from "../components/page-index/sections/DailyJournalSection.astro";
 import PresentationsSection from "../components/page-index/sections/PresentationsSection.astro";
 import SocialNetworkServicesSection from "../components/page-index/sections/SocialNetworkServicesSection.astro";
 import AddressSection from "../components/page-index/sections/AddressSection.astro";
@@ -44,6 +45,12 @@ import AddressSection from "../components/page-index/sections/AddressSection.ast
       </p>
     </CareerInfoSection>
     <OpenSourceActivitySection />
+    <DailyJournalSection>
+      <p>
+        <a href="https://scrapbox.io/">Scrapbox</a
+        >を活用し、日々の出来事や気になるニュースを日報という形でまとめています。毎日更新ではなく、気が向いたら更新しています。
+      </p>
+    </DailyJournalSection>
     <PresentationsSection />
     <SocialNetworkServicesSection />
     <AddressSection />


### PR DESCRIPTION
- ZennとScrapboxをSNSより削除
  - Zenn は活用していないため
  - Scrapbox はソーシャルサービスという扱いでよいか懐疑的になったため
- Scrapboxを日報という形で管理するようにする