### PR TITLE
Revert "markuplint の実行において ts-node が存在しないためエラーが発生するものの暫定対策"

### DIFF
--- a/.github/workflows/markuplint.yml
+++ b/.github/workflows/markuplint.yml
@@ -26,7 +26,6 @@ jobs:
       run: |
         yarn install
         yarn build
-        rm -rf node_modules
         yarn markuplint
       env:
         CI: true

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "yarn eslint && yarn markuplint",
     "eslint": "eslint --ext .ts,.astro --ignore-path .gitignore .",
     "eslint:fix": "eslint --fix --ext .ts,.astro --ignore-path .gitignore .",
-    "markuplint": "npx markuplint 'dist/**/*.html'",
+    "markuplint": "markuplint 'dist/**/*.html'",
     "prettier": "yarn prettier:ts && yarn prettier:astro",
     "prettier:ts": "prettier --check 'src/**/*.ts'",
     "prettier:astro": "prettier --check 'src/**/*.astro'",


### PR DESCRIPTION
Reverts yamanoku/yamanoku.github.io#1290

[Add ESM support and change to jiti by Codex- · Pull Request #106 · Codex-/cosmiconfig-typescript-loader](https://togithub.com/Codex-/cosmiconfig-typescript-loader/pull/106) の対応を受けて