### PR TITLE
`<link>` に `rel=me` を付与してリンク先を本人認証する

### DIFF
--- a/.markuplintrc
+++ b/.markuplintrc
@@ -21,16 +21,6 @@
         },
         "required-attr": false
       }
-    },
-    {
-      "selector": "a[rel]",
-      "rules": {
-        "invalid-attr": {
-          "options": {
-            "allowAttrs": ["rel", "me"]
-          }
-        }
-      }
     }
   ]
 }

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -28,3 +28,5 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 <link rel="canonical" href={canonicalURL} />
 <link rel="alternate" hreflang="ja" href="https://yamanoku.net/" />
 <link rel="alternate" hreflang="en-us" href="https://yamanoku.net/en/" />
+<link rel="me" href="https://mstdn.jp/@yamanoku" />
+<link rel="me" href="https://www.threads.net/@yamanoku" />

--- a/src/components/global/GlobalTypes.ts
+++ b/src/components/global/GlobalTypes.ts
@@ -1,7 +1,6 @@
 export type LinkItem = {
   url?: string;
   title?: string;
-  rel?: string;
 };
 
 export type ListItem = LinkItem & {

--- a/src/components/page-index/sections/SocialNetworkServicesSection.astro
+++ b/src/components/page-index/sections/SocialNetworkServicesSection.astro
@@ -25,8 +25,7 @@ const t = useTranslations(Astro);
       },
       {
         title: "Mastodon",
-        url: "https://mstdn.jp/@yamanoku",
-        rel: "me"
+        url: "https://mstdn.jp/@yamanoku"
       }
     ]}
   />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -8,7 +8,7 @@ const lang = getLanguageFromURL(Astro.url.pathname);
 const pageTitle: string = Astro.props.title;
 ---
 
-<!DOCTYPE html>
+<!doctype html>
 <html lang={lang}>
   <head>
     <BaseHead title={`${pageTitle} | yamanoku.net`} />


### PR DESCRIPTION
分散SNSで `link rel="me"` によって本人認証できるサービスを追加していく。

以前 https://github.com/yamanoku/yamanoku.github.io/pull/1292 で対応したが、a 要素に rel を無理やり付与していたのでその対応自体も差し戻す。