### PR TITLE
add: text beside logo

### DIFF
--- a/src/components/global/GlobalHeader.astro
+++ b/src/components/global/GlobalHeader.astro
@@ -5,13 +5,13 @@ const t = useTranslations(Astro);
 ---
 
 <header class="max-w-[80ch] m-auto py-0 px-y-rhythm-2">
-  <div class="flex my-y-rhythm-2 mx-0">
+  <div class="inline-flex items-center gap-y-rhythm-1 my-y-rhythm-2 mx-0">
     <svg
       width="48"
       height="48"
       viewBox="0 0 246 242"
       role="img"
-      aria-label="yamanoku logo"
+      aria-label="yamanoku"
     >
       <path
         class="translate-x-[-64px] translate-y-[-67px] fill-[#36465d] dark:fill-y-white-base"
@@ -19,6 +19,7 @@ const t = useTranslations(Astro);
         d="M64,67v54l82,82-46,46v60h56L310,155V96H230l-21,20L160,67H64ZM176,203l-45,46h25L293,113H230l-39,39-31-31H94Z"
       ></path>
     </svg>
+    <span>{t("header.text-beside-logo")}</span>
   </div>
   <nav
     class="flex flex-wrap justify-start items-center gap-y-rhythm-2"

--- a/src/i18n/en/dictionary.ts
+++ b/src/i18n/en/dictionary.ts
@@ -4,6 +4,9 @@ export default Dictionary({
   // meta infomation
   "meta.description": "Okuto Oyama Portfolio Site",
 
+  // header
+  "header.text-beside-logo": "Portal Site",
+
   // heading
   "heading.basic": "Basic Info",
   "heading.jobs": "Career Info",

--- a/src/i18n/ja/dictionary.ts
+++ b/src/i18n/ja/dictionary.ts
@@ -2,6 +2,9 @@ export default {
   // meta 情報
   "meta.description": "大山奥人のポートフォリオサイト",
 
+  // header
+  "header.text-beside-logo": "ポータルサイト",
+
   // 見出し
   "heading.basic": "基本情報",
   "heading.jobs": "職業",


### PR DESCRIPTION
| https://archives.yamanoku.net/ | https://2023.yamanoku.net/ | 
| ----- | ----- |
| ![archives.yamanoku.netのヘッダー部分。yamanokuロゴ横に「アーカイブ」のリンクテキストが設置されている](https://github.com/yamanoku/yamanoku.github.io/assets/1996642/a3f8cc43-f8ad-4db6-a8a8-1f9980a1bdf9) | ![2023.yamanoku.netのヘッダー部分。yamanokuロゴ横に「Advent Calendar 2023」のリンクテキストが設置されている](https://github.com/yamanoku/yamanoku.github.io/assets/1996642/a7ce1bf4-dbb3-40a2-9a64-d2ff750244ff) |

サブドメインサイトにてロゴ横にサイトの役割を明示するようになったのでポータルサイト側でも同じように設定してみる

| 日本語 | English |
| ----- | ----- |
| ![yamanokuロゴ横に「ポータルサイト」というテキストが設置されている](https://github.com/yamanoku/yamanoku.github.io/assets/1996642/95996dd5-08e9-4e03-b0c4-86c069bd486b) | ![yamanokuロゴ横に「Portal Site」というテキストが設置されている](https://github.com/yamanoku/yamanoku.github.io/assets/1996642/33ef9369-8787-459a-9147-7469b6919632) |
