### PR TITLE
Biomeでdeprecatedになったものを更新

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -17,7 +17,7 @@
   "javascript": {
     "formatter": {
       "indentStyle": "space",
-      "trailingComma": "none"
+      "trailingCommas": "none"
     }
   },
   "linter": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "lint": "yarn biome && yarn markuplint",
-    "biome": "biome check --apply .",
+    "biome": "biome check --write .",
     "biome:ci": "biome ci .",
     "markuplint": "markuplint 'dist/**/*.html'",
     "deploy": "gh-pages -d dist -b main -m 'chore: deploy [skip ci]' -t"


### PR DESCRIPTION
```sh
⚠ The argument --apply is deprecated, it will be removed in the next major release. Use --write instead.
```

```sh
⚠ The property trailingComma is deprecated. Use javascript.formatter.trailingCommas instead.
```