### PR TITLE
fix: correct ECMAScript enums presentation date to 2025-06-06

### DIFF
--- a/src/presentations/listPresentation.ts
+++ b/src/presentations/listPresentation.ts
@@ -12,7 +12,7 @@ export const listStage: ExactPresantationLengthArray<ListType> = [
   {
     title: "Proposal for ECMAScript enumsについて（2025-06-06時点）",
     url: "https://scrapbox.io/yamanoku/Proposal_for_ECMAScript_enums%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6%EF%BC%882025-06-06%E6%99%82%E7%82%B9%EF%BC%89",
-    datetime: "2025-06-07T19:48:00.00+09:00"
+    datetime: "2025-06-06T19:48:00.00+09:00"
   },
   {
     title:


### PR DESCRIPTION
Correct the presentation date from 2025-06-07 to 2025-06-06

- Update datetime for "Proposal for ECMAScript enumsについて（2025-06-06時点）" presentation
- Fix date error as requested by yamanoku

Closes #1853

Generated with [Claude Code](https://claude.ai/code)