### PR TITLE
chore(records): add wrangler config for Cloudflare Pages

### DIFF
--- a/records/README.md
+++ b/records/README.md
@@ -44,7 +44,9 @@ Cloudflare Pages のダッシュボードで GitHub リポジトリ（`yamanoku/
 | Production branch | `main` |
 | Root directory | （リポジトリルートのまま） |
 | Build command | `pnpm install --frozen-lockfile && pnpm --filter records build` |
-| Build output directory | `records/dist` |
+| Build output directory | `records/dist`（リポジトリルートの `wrangler.jsonc` で指定） |
+
+ビルド出力ディレクトリはリポジトリルートの `wrangler.jsonc`（`pages_build_output_dir: "records/dist"`）で構成しているため、Cloudflare Pages はこの設定を参照する。ダッシュボードの Build output directory 欄は空でもよい（設定した場合は wrangler.jsonc が優先）。
 
 - **Node バージョン**: `records/.node-version`（`22`）で固定。ダッシュボードの環境変数 `NODE_VERSION` でも指定可。
 - **pnpm**: ルート `package.json` の `packageManager: pnpm@11.6.0` を corepack 経由で使用（catalog 解決に必要）。

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,6 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "records",
+  "compatibility_date": "2026-06-14",
+  "pages_build_output_dir": "records/dist"
+}


### PR DESCRIPTION
## 概要

records サイト（`records.yamanoku.net`）の Cloudflare Pages プロジェクトをコード管理するため、リポジトリルートに `wrangler.jsonc` を追加します。Cloudflare 側との Git 連携設定はすでに完了済みです。

## 変更内容

### `wrangler.jsonc`（リポジトリルート）
```jsonc
{
  "$schema": "node_modules/wrangler/config-schema.json",
  "name": "records",
  "compatibility_date": "2026-06-14",
  "pages_build_output_dir": "records/dist"
}
```

- `pages_build_output_dir` でビルド出力先を `records/dist` に指定
- pnpm workspace（catalog/lockfile）の解決のため install はモノレポルートで行う必要があり、Cloudflare Pages の Root directory もリポジトリルートのため、wrangler 設定ファイルもルートに配置
- `name: "records"` で Pages プロジェクトを識別

### `records/README.md`
- ビルド出力先が `wrangler.jsonc` で管理される旨を追記

## 検証

- ✅ `wrangler.jsonc` は有効な JSON で、`pages_build_output_dir` が実在の出力（`records/dist/index.html`）を指すことを確認
- ✅ `pnpm --filter records build` 成功
- ✅ `biome ci .` エラー・警告なし

> 実デプロイの認証は Cloudflare の Git 連携がサーバー側で処理するため、ローカルからの `wrangler pages deploy` は実行していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)