### PR TITLE
docs(records): clarify Cloudflare Pages deploy & build watch paths

### DIFF
--- a/records/README.md
+++ b/records/README.md
@@ -49,6 +49,24 @@ Cloudflare Pages のダッシュボードで GitHub リポジトリ（`yamanoku/
 - **Node バージョン**: `records/.node-version`（`22`）で固定。ダッシュボードの環境変数 `NODE_VERSION` でも指定可。
 - **pnpm**: ルート `package.json` の `packageManager: pnpm@11.6.0` を corepack 経由で使用（catalog 解決に必要）。
 - **カスタムドメイン**: `records.yamanoku.net` を Cloudflare Pages のカスタムドメインとして追加（DNS は Cloudflare 側で設定）。
-- **Build watch paths**（任意）: `records/` に絞ると、関係ないファイル変更での無駄なビルドを抑制できる。
 
 > Git 連携はモノレポルートで `pnpm install` を実行する。`--filter records` によりビルド対象は records のみに限定され、`presentations`（11ty/Slidev）の重いビルドは走らない。
+
+### `wrangler.jsonc` は使わない
+
+このリポジトリには Cloudflare Pages プロジェクトが **2つ**（`yamanoku-net` / `records-yamanoku`）あり、どちらも Root directory がリポジトリルートのため、ルート直下に `wrangler.jsonc` を置くと **両方のプロジェクトが同じ設定を読み込んでしまう**。`name` や `pages_build_output_dir` がもう一方のプロジェクトと一致せずビルドが失敗するため、`wrangler.jsonc` は配置しない。出力先はダッシュボードの **Build output directory（`records/dist`）** で設定する。
+
+### records 変更時のみデプロイする（Build watch paths）
+
+各プロジェクトのデプロイを変更パスで絞り込むには、Cloudflare Pages ダッシュボードの **Settings → Builds & deployments → Build watch paths** を設定する（コード/`wrangler.jsonc` では指定できないダッシュボード専用設定）。
+
+| プロジェクト | 設定 | 値 |
+| --- | --- | --- |
+| `records-yamanoku` | Include paths | `records/*`, `packages/yama-normalize/*`, `pnpm-lock.yaml`, `pnpm-workspace.yaml` |
+| `yamanoku-net` | Exclude paths | `records/*` |
+
+この設定により次のように振り分けられる。
+
+- `records/` 配下のみの変更 → `records-yamanoku` のみビルド
+- 本体サイト（`src/` など）のみの変更 → `yamanoku-net` のみビルド
+- 共有依存（`packages/yama-normalize`・ルートの lockfile / workspace）の変更 → 両方ビルド


### PR DESCRIPTION
## 背景

#2180 でルート直下に `wrangler.jsonc` を追加したところ、`Cloudflare Pages: yamanoku-net` のビルドが失敗しました。

同リポジトリには Cloudflare Pages プロジェクトが **2つ**（`yamanoku-net` / `records-yamanoku`）あり、どちらも Root directory がリポジトリルートのため、ルート直下の `wrangler.jsonc` を **両方が読み込んでしまう**ことが原因です（`name: "records"` / `pages_build_output_dir: "records/dist"` が `yamanoku-net` と不一致でビルド失敗）。

records は pnpm workspace の catalog / `workspace:*` 解決のため install をルートで行う必要があり、`wrangler.jsonc` を `records/` に隔離することもできません。よって `wrangler.jsonc` は使わず、ダッシュボード設定に寄せる方針とします（#2180 はクローズ済み）。

## 変更内容（ドキュメントのみ）

`records/README.md` のデプロイ節を更新：

- **`wrangler.jsonc` は使わない**理由を明記。出力先はダッシュボードの Build output directory（`records/dist`）で設定
- **records 変更時のみ `records-yamanoku` をデプロイする**ための **Build watch paths**（ダッシュボード専用設定）を両プロジェクト分ドキュメント化

| プロジェクト | 設定 | 値 |
| --- | --- | --- |
| `records-yamanoku` | Include paths | `records/*`, `packages/yama-normalize/*`, `pnpm-lock.yaml`, `pnpm-workspace.yaml` |
| `yamanoku-net` | Exclude paths | `records/*` |

## 要・手動設定（ダッシュボード）

Build watch paths はコードで表現できないため、上表のとおり**ダッシュボードでの設定が別途必要**です。設定後の挙動：

- `records/` のみ変更 → `records-yamanoku` のみビルド
- 本体サイトのみ変更 → `yamanoku-net` のみビルド
- 共有依存の変更 → 両方ビルド

🤖 Generated with [Claude Code](https://claude.com/claude-code)