### PR TITLE
feat(records): ヘッダー・フッターを追加し中央寄せレイアウトを廃止

### DIFF
--- a/records/src/components/global/GlobalFooter.astro
+++ b/records/src/components/global/GlobalFooter.astro
@@ -1,0 +1,13 @@
+---
+const today = new Date();
+---
+
+<footer>
+  <p>&copy; Copyright {today.getFullYear()}, Okuto Oyama</p>
+  <p>
+    Source :
+    <a href="https://github.com/yamanoku/yamanoku.github.io/"
+      >yamanoku/yamanoku.github.io</a
+    >
+  </p>
+</footer>

--- a/records/src/components/global/GlobalHeader.astro
+++ b/records/src/components/global/GlobalHeader.astro
@@ -1,0 +1,27 @@
+---
+---
+
+<header>
+  <div class="inline-flex items-center gap-y-rhythm-1 my-y-rhythm-2 mx-0">
+    <svg
+      width="48"
+      height="48"
+      viewBox="0 0 246 242"
+      role="img"
+      aria-label="yamanoku"
+    >
+      <path
+        class="translate-x-[-64px] translate-y-[-67px] fill-y-identity-color dark:fill-y-white-base"
+        fill-rule="evenodd"
+        d="M64,67v54l82,82-46,46v60h56L310,155V96H230l-21,20L160,67H64ZM176,203l-45,46h25L293,113H230l-39,39-31-31H94Z"
+      ></path>
+    </svg>
+    <span>Records</span>
+  </div>
+  <nav
+    class="flex flex-wrap justify-start items-center gap-y-rhythm-2"
+    aria-label="関連ページ"
+  >
+    <a href="https://yamanoku.net">ポータルサイト</a>
+  </nav>
+</header>

--- a/records/src/layouts/Layout.astro
+++ b/records/src/layouts/Layout.astro
@@ -1,4 +1,7 @@
 ---
+import GlobalFooter from "../components/global/GlobalFooter.astro";
+import GlobalHeader from "../components/global/GlobalHeader.astro";
+
 import "../styles/global.css";
 
 interface Props {
@@ -37,15 +40,9 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
     <link rel="canonical" href={canonicalURL} />
   </head>
   <body>
+    <GlobalHeader />
     <slot />
+    <GlobalFooter />
   </body>
 </html>
 
-<style>
-  body {
-    max-width: 60rem;
-    margin-inline: auto;
-    padding-inline: 1rem;
-    padding-block: 2rem;
-  }
-</style>

--- a/records/src/pages/index.astro
+++ b/records/src/pages/index.astro
@@ -4,7 +4,7 @@ import Layout from "../layouts/Layout.astro";
 ---
 
 <Layout>
-  <main>
+  <main id="main">
     <Content />
   </main>
 </Layout>


### PR DESCRIPTION
## 概要

records サイト（records.yamanoku.net）のページ構成を本体サイト（`src/pages/`）と揃えます。ヘッダー・フッターを追加し、中央寄せレイアウトを廃止しました。

## 変更内容

- `records/src/components/global/GlobalHeader.astro` を追加
  - 本体サイトの `GlobalHeader` を踏襲。ロゴ SVG + `Records` ラベル + ポータルサイト（`https://yamanoku.net`）へのリンク
  - records は単一言語サイトのため、本体の言語切り替えナビは設けず関連ページリンクに置き換え
- `records/src/components/global/GlobalFooter.astro` を追加
  - 著作権表記 + ソースリンク（standalone サイトのため `<a>` をインライン化）
- `records/src/layouts/Layout.astro`
  - `GlobalHeader` / `GlobalFooter` を `slot` の前後に配置
  - body の中央寄せスタイル（`max-width: 60rem; margin-inline: auto`）を削除
- `records/src/pages/index.astro`
  - `<main>` に `id="main"` を付与（本体サイトと統一）

## 中央寄せ廃止の根拠

`yama-normalize.css` が `:where(header, main, footer)` を `max-inline-size`（ja は `45rem`）で `margin: auto` なしに制御しているため、本体サイト同様に左寄せ・幅制限のレイアウトになります。records 側の `body` の中央寄せ指定はこれを上書きしていたため不要です。

## 確認

- `pnpm --filter records build` が成功
- 出力 HTML に `<header>` / `<footer>` / `id="main"` が含まれ、`margin-inline: auto` が 0 件であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)