### PR TITLE
feat: TOPページのRecordsリンクを records.yamanoku.net に変更

### DIFF
--- a/src/components/page-index/sections/PresentationsSection.astro
+++ b/src/components/page-index/sections/PresentationsSection.astro
@@ -15,13 +15,13 @@ const t = useTranslations(Astro);
   {
     lang === "en" ? (
       <p>
-        Please see <a href="https://github.com/yamanoku/records">Records</a> for
-        past stage.
+        Please see <a href="https://records.yamanoku.net/">Records</a> for past
+        stage.
       </p>
     ) : (
       <p>
         過去の登壇については
-        <a href="https://github.com/yamanoku/records">Records</a>
+        <a href="https://records.yamanoku.net/">Records</a>
         を参照してください。
       </p>
     )


### PR DESCRIPTION
## 概要

TOPページ（登壇セクション）のRecordsへのリンクを `https://github.com/yamanoku/records` から `https://records.yamanoku.net/` に変更しました。

## 変更内容

- `src/components/page-index/sections/PresentationsSection.astro` の英語・日本語両方のRecordsリンクを更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)