### PR TITLE
feat: 発表資料の開発サーバー起動コマンドを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,11 @@ pnpm preview
 
 # リント・フォーマット
 pnpm lint
+
+# 発表資料の開発サーバー（flat: 11tyのみ8080 / monorepo: 11ty 8080 + Slidev 3030）
+pnpm --filter records dev:presentation <name>
+pnpm --filter records dev:presentation <name> --slide  # Slidevのみ
+pnpm --filter records dev:presentation <name> --pages  # 11tyのみ
 ```
 
 ## コードスタイルガイドライン
@@ -134,6 +139,15 @@ const { title, items = [] } = Astro.props;
 
 #### ビルド
 `records/scripts/build-presentations.mjs` がすべてのプレゼンテーションをビルドし `records/dist/<name>/` に出力する。`pnpm --filter records build` 実行時にAstroビルドの後に自動実行される。
+
+プレゼンテーションの一覧（name / type / wip）は `records/scripts/presentations.mjs` で一元管理しており、ビルド・開発サーバー両スクリプトが参照する。資料を追加したらこのファイルに追記する（`wip: true` はビルド対象外）。
+
+#### デバッグ（開発サーバー）
+`records/scripts/dev-presentation.mjs` で各資料の開発サーバーを起動できる。flat型は11ty（8080）、monorepo型は11ty（8080）+ Slidev（3030）を同時起動し、Ctrl+Cで両方停止する。`--pages` / `--slide` で片方のみ起動可能。
+
+```bash
+pnpm --filter records dev:presentation <name>
+```
 
 #### プレゼンテーション一覧データ
 `src/presentations/listPresentation.ts` にポートフォリオサイトに表示する登壇・執筆一覧を管理。`ExactPresantationLengthArray` 型で5件で固定されている。

--- a/records/README.md
+++ b/records/README.md
@@ -44,7 +44,24 @@ pnpm --filter records preview
 - **flat 型**: 11ty のみ（`<name>/.eleventy.js`、原稿 `<name>/pages/`）
 - **monorepo 型**: 11ty（原稿）+ Slidev（スライド）（`<name>/11ty/`・`<name>/slidev/`、スライドは `/<name>/slide/` で配信）
 - 共通の 11ty 設定は `records/presentations/_shared/eleventy-base.js`
+- 資料の一覧（name / type / wip）は `records/scripts/presentations.mjs` で一元管理。資料を追加したらここに追記する（`wip: true` はビルド対象外）
 - ビルドは `records/scripts/build-presentations.mjs` が全資料を 11ty / Slidev でビルドし `records/dist/<name>/` にコピーする（`pnpm --filter records build` から自動実行）
+
+#### デバッグ（開発サーバー）
+
+`records/scripts/dev-presentation.mjs` で資料ごとに開発サーバーを起動できる。flat 型は 11ty（http://localhost:8080/）、monorepo 型は 11ty（8080）と Slidev（http://localhost:3030/）を同時に起動し、Ctrl+C で両方停止する。
+
+```bash
+# 資料名を指定して起動（引数なし・不明な名前のときは利用可能な一覧を表示）
+pnpm --filter records dev:presentation <name>
+
+# monorepo 型で片方だけ起動する
+pnpm --filter records dev:presentation <name> --slide  # Slidev のみ
+pnpm --filter records dev:presentation <name> --pages  # 11ty のみ
+```
+
+- 11ty は `docs/` に書き出しながら配信するが、`records/presentations/*/docs/` は gitignore 済みのため git は汚れない
+- Slidev の開発サーバーはルート（`/`）配信のため `--base` は不要。11ty ページ内のスライドリンクは本番 URL のハードコードなので、開発中は各ポートを直接開く
 
 ## デプロイ（Cloudflare Pages / Git 連携）
 

--- a/records/package.json
+++ b/records/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "astro dev",
+    "dev:presentation": "node scripts/dev-presentation.mjs",
     "build": "astro build && node scripts/build-presentations.mjs",
     "preview": "astro preview"
   },

--- a/records/scripts/build-presentations.mjs
+++ b/records/scripts/build-presentations.mjs
@@ -1,24 +1,15 @@
 import { execSync } from "node:child_process";
 import { cpSync } from "node:fs";
 import { resolve } from "node:path";
+import { presentations } from "./presentations.mjs";
 
 const presRoot = resolve("presentations");
 const eleventyBin = resolve(presRoot, "node_modules", ".bin", "eleventy");
 const slidevBin = resolve(presRoot, "node_modules", ".bin", "slidev");
 
-const presentations = [
-  { name: "tskaigi-2026", type: "monorepo" },
-  { name: "burikaigi-2026", type: "monorepo" },
-  { name: "vuefes-japan-2025", type: "monorepo" },
-  { name: "tskaigi-2025", type: "flat" },
-  { name: "frontendo-2024", type: "flat" },
-  { name: "vuefes-japan-2023", type: "flat" },
-  { name: "vuefes-japan-online-2022", type: "flat" },
-  { name: "jsconfjp-2021", type: "flat" },
-  { name: "vue-a11y-2019", type: "flat" },
-];
-
 for (const pres of presentations) {
+  if (pres.wip) continue;
+
   const presDir = resolve(presRoot, pres.name);
   const outputDir = resolve("dist", pres.name);
 

--- a/records/scripts/dev-presentation.mjs
+++ b/records/scripts/dev-presentation.mjs
@@ -1,0 +1,88 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { presentations } from "./presentations.mjs";
+
+const presRoot = resolve("presentations");
+const eleventyBin = resolve(presRoot, "node_modules", ".bin", "eleventy");
+const slidevBin = resolve(presRoot, "node_modules", ".bin", "slidev");
+
+const ELEVENTY_URL = "http://localhost:8080/";
+const SLIDEV_URL = "http://localhost:3030/";
+
+const [name, flag] = process.argv.slice(2);
+const pres = presentations.find((p) => p.name === name);
+
+if (!pres) {
+  console.error(
+    name
+      ? `Unknown presentation: ${name}`
+      : "Usage: pnpm --filter records dev:presentation <name> [--pages|--slide]",
+  );
+  console.error("Available presentations:");
+  for (const p of presentations) {
+    console.error(`  ${p.name} (${p.type})`);
+  }
+  process.exit(1);
+}
+
+const presDir = resolve(presRoot, pres.name);
+
+function eleventyJob(cwd) {
+  return {
+    bin: eleventyBin,
+    args: ["--serve"],
+    cwd,
+    label: "11ty",
+    url: ELEVENTY_URL,
+  };
+}
+
+function slidevJob(cwd) {
+  if (!existsSync(resolve(cwd, "slides.md"))) {
+    console.error(`slides.md not found in ${cwd}. Create it first.`);
+    process.exit(1);
+  }
+  return {
+    bin: slidevBin,
+    args: [],
+    cwd,
+    label: "Slidev",
+    url: SLIDEV_URL,
+  };
+}
+
+const jobs = [];
+if (pres.type === "flat") {
+  jobs.push(eleventyJob(presDir));
+} else if (pres.type === "monorepo") {
+  if (flag !== "--slide") {
+    jobs.push(eleventyJob(resolve(presDir, "11ty")));
+  }
+  if (flag !== "--pages") {
+    jobs.push(slidevJob(resolve(presDir, "slidev")));
+  }
+} else {
+  jobs.push(slidevJob(resolve(presDir, "slidev")));
+}
+
+const children = jobs.map((job) => {
+  console.log(`Starting ${job.label} for ${pres.name} (${job.url})...`);
+  return spawn(job.bin, job.args, { cwd: job.cwd, stdio: "inherit" });
+});
+
+const killAll = () => {
+  for (const child of children) {
+    if (child.exitCode === null) {
+      child.kill("SIGINT");
+    }
+  }
+};
+process.on("SIGINT", killAll);
+process.on("SIGTERM", killAll);
+for (const child of children) {
+  child.on("exit", (code) => {
+    killAll();
+    process.exitCode = code ?? 0;
+  });
+}

--- a/records/scripts/presentations.mjs
+++ b/records/scripts/presentations.mjs
@@ -1,0 +1,12 @@
+export const presentations = [
+  { name: "dai-kichijojipm-2026", type: "slidev", wip: true },
+  { name: "tskaigi-2026", type: "monorepo" },
+  { name: "burikaigi-2026", type: "monorepo" },
+  { name: "vuefes-japan-2025", type: "monorepo" },
+  { name: "tskaigi-2025", type: "flat" },
+  { name: "frontendo-2024", type: "flat" },
+  { name: "vuefes-japan-2023", type: "flat" },
+  { name: "vuefes-japan-online-2022", type: "flat" },
+  { name: "jsconfjp-2021", type: "flat" },
+  { name: "vue-a11y-2019", type: "flat" },
+];


### PR DESCRIPTION
## 概要

records/presentations 配下の登壇資料（11ty / Slidev）をローカルでデバッグする手段がなかったため、開発サーバー起動用のスクリプトを追加しました。

```bash
pnpm --filter records dev:presentation <name>          # flat: 11ty(8080) / monorepo: 11ty(8080)+Slidev(3030)
pnpm --filter records dev:presentation <name> --slide  # monorepo: Slidevのみ
pnpm --filter records dev:presentation <name> --pages  # monorepo: 11tyのみ
```

## 変更内容

- **新規 `records/scripts/presentations.mjs`**: 資料一覧（name / type / wip）を一元管理。ビルド・dev 両スクリプトから参照
- **新規 `records/scripts/dev-presentation.mjs`**: 開発サーバー起動スクリプト。既存ビルドスクリプトと同じく `node_modules/.bin` から bin を解決し、`node:child_process` の spawn で起動（新規依存なし）。monorepo 型は 11ty + Slidev を同時起動し、Ctrl+C で両方停止。片方が落ちたら残りも kill するクリーンアップ付き
- **変更 `records/scripts/build-presentations.mjs`**: インラインの一覧を共有モジュールの import に置き換え、`wip: true` はスキップ
- **変更 `records/package.json`**: `dev:presentation` スクリプトを追加
- **変更 `CLAUDE.md` / `records/README.md`**: 使い方と一覧管理の説明を追記

WIP の `dai-kichijojipm-2026` は `type: "slidev", wip: true` として登録し、ビルド対象外のままです（`slides.md` 未作成のため dev 起動時は案内エラーを表示）。

## 動作確認

- [x] 引数なし・不明な名前で利用可能な一覧を表示して exit 1
- [x] flat 型（tskaigi-2025）: 8080 が 200 応答、停止後プロセス残りなし
- [x] monorepo 型（tskaigi-2026）: 8080 / 3030 両方 200 応答、停止後オーファンなし。`--pages` / `--slide` で片方のみ起動
- [x] slidev 型（dai-kichijojipm-2026）: slides.md 未作成の案内エラーで終了
- [x] ビルド回帰: `pnpm --filter records build` 成功、`records/dist/` に従来どおり 9 件出力
- [x] `pnpm biome` エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)