### PR TITLE
feat: お元気ですか.fmセクションとRSS自動更新ワークフローを追加

### DIFF
--- a/.github/workflows/update-ogenkidesuka-fm.yml
+++ b/.github/workflows/update-ogenkidesuka-fm.yml
@@ -1,4 +1,4 @@
-name: Update Ogenkidesuka.fm
+name: Update お元気ですか.fm
 
 # お元気ですか.fm のRSSを定期取得し、最新エピソードに差分があれば
 # src/data/ogenkidesukaFm.json を更新して main にコミットする。
@@ -20,15 +20,12 @@ concurrency:
 jobs:
   update:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [22.x]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js (latest LTS)
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 'lts/*'
       - name: Fetch latest episodes
         run: node scripts/fetch-ogenkidesuka-fm.mjs
       - name: Commit and push if changed

--- a/.github/workflows/update-ogenkidesuka-fm.yml
+++ b/.github/workflows/update-ogenkidesuka-fm.yml
@@ -1,0 +1,44 @@
+name: Update Ogenkidesuka.fm
+
+# お元気ですか.fm のRSSを定期取得し、最新エピソードに差分があれば
+# src/data/ogenkidesukaFm.json を更新して main にコミットする。
+# main への push で Cloudflare Pages の自動デプロイがトリガーされる。
+
+on:
+  schedule:
+    # 毎日 00:00 UTC（09:00 JST）に実行
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-ogenkidesuka-fm
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22.x]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Fetch latest episodes
+        run: node scripts/fetch-ogenkidesuka-fm.mjs
+      - name: Commit and push if changed
+        run: |
+          if git diff --quiet -- src/data/ogenkidesukaFm.json; then
+            echo "お元気ですか.fm の更新はありません"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/data/ogenkidesukaFm.json
+          git commit -m "chore: お元気ですか.fm の最新エピソードを更新"
+          git push

--- a/scripts/fetch-ogenkidesuka-fm.mjs
+++ b/scripts/fetch-ogenkidesuka-fm.mjs
@@ -1,0 +1,85 @@
+// お元気ですか.fm のRSSフィードを取得し、最新5話を src/data/ogenkidesukaFm.json に書き出す。
+// GitHub Actions（.github/workflows/update-ogenkidesuka-fm.yml）から定期実行され、
+// 差分があればコミット・pushしてデプロイをトリガーする。
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const RSS_URL = "https://anchor.fm/s/65c3f018/podcast/rss";
+const EPISODE_LIMIT = 5;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUTPUT_PATH = resolve(__dirname, "../src/data/ogenkidesukaFm.json");
+
+// <item>...</item> をすべて取り出す
+const extractItems = (xml) => {
+  const items = [];
+  const regex = /<item>([\s\S]*?)<\/item>/g;
+  let match = regex.exec(xml);
+  while (match !== null) {
+    items.push(match[1]);
+    match = regex.exec(xml);
+  }
+  return items;
+};
+
+// タグの中身を取り出す（CDATAにも対応）
+const pickTag = (item, tag) => {
+  const regex = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`);
+  const match = item.match(regex);
+  if (!match) {
+    return "";
+  }
+  const cdata = match[1].match(/^\s*<!\[CDATA\[([\s\S]*?)\]\]>\s*$/);
+  return (cdata ? cdata[1] : match[1]).trim();
+};
+
+// チャンネル（<item>より前）のホームURLを取り出す
+const parseChannelLink = (xml) => {
+  const channel = xml.split("<item>")[0];
+  return pickTag(channel, "link");
+};
+
+const parseEpisodes = (xml) =>
+  extractItems(xml)
+    .slice(0, EPISODE_LIMIT)
+    .map((item) => {
+      const title = pickTag(item, "title");
+      const url = pickTag(item, "link");
+      const pubDate = pickTag(item, "pubDate");
+      const datetime = pubDate ? new Date(pubDate).toISOString() : "";
+      return { title, url, datetime };
+    });
+
+const main = async () => {
+  const response = await fetch(RSS_URL);
+  if (!response.ok) {
+    throw new Error(`RSSの取得に失敗しました: ${response.status} ${response.statusText}`);
+  }
+  const xml = await response.text();
+  const homeUrl = parseChannelLink(xml);
+  const episodes = parseEpisodes(xml);
+
+  if (episodes.length === 0) {
+    throw new Error("エピソードを1件も取得できませんでした");
+  }
+  for (const episode of episodes) {
+    if (!episode.title || !episode.url || !episode.datetime) {
+      throw new Error(`エピソード情報が不完全です: ${JSON.stringify(episode)}`);
+    }
+  }
+
+  const data = {
+    feedUrl: RSS_URL,
+    homeUrl: homeUrl || RSS_URL,
+    episodes
+  };
+  await mkdir(dirname(OUTPUT_PATH), { recursive: true });
+  await writeFile(OUTPUT_PATH, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+  console.log(`${episodes.length}件のエピソードを ${OUTPUT_PATH} に書き出しました`);
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/fetch-ogenkidesuka-fm.mjs
+++ b/scripts/fetch-ogenkidesuka-fm.mjs
@@ -44,11 +44,13 @@ const parseEpisodes = (xml) =>
   extractItems(xml)
     .slice(0, EPISODE_LIMIT)
     .map((item) => {
+      // Content Collections の file() ローダーは各エントリに id を要求するため guid を採用
+      const id = pickTag(item, "guid");
       const title = pickTag(item, "title");
       const url = pickTag(item, "link");
       const pubDate = pickTag(item, "pubDate");
       const datetime = pubDate ? new Date(pubDate).toISOString() : "";
-      return { title, url, datetime };
+      return { id, title, url, datetime };
     });
 
 const main = async () => {
@@ -64,7 +66,7 @@ const main = async () => {
     throw new Error("エピソードを1件も取得できませんでした");
   }
   for (const episode of episodes) {
-    if (!episode.title || !episode.url || !episode.datetime) {
+    if (!episode.id || !episode.title || !episode.url || !episode.datetime) {
       throw new Error(`エピソード情報が不完全です: ${JSON.stringify(episode)}`);
     }
   }

--- a/src/components/page-index/sections/OgenkidesukaFmSection.astro
+++ b/src/components/page-index/sections/OgenkidesukaFmSection.astro
@@ -1,12 +1,16 @@
 ---
+import { getCollection } from "astro:content";
 import ogenkidesukaFm from "../../../data/ogenkidesukaFm.json";
 import { getLanguageFromURL, useTranslations } from "../../../i18n/util";
 import GlobalListComponent from "../../global/GlobalListComponent.astro";
 import type { ListItem } from "../../global/GlobalTypes";
 
-// お元気ですか.fm のRSSから生成した最新エピソード一覧。
-// データは scripts/fetch-ogenkidesuka-fm.mjs が src/data/ogenkidesukaFm.json に生成する。
-const episodes: ListItem[] = ogenkidesukaFm.episodes;
+// エピソード一覧はContent Collectionsから読み込み、新しい順に並べる
+const episodes: ListItem[] = (await getCollection("ogenkidesukaFm"))
+  .map((entry) => entry.data)
+  .sort((a, b) => b.datetime.localeCompare(a.datetime));
+
+// homeUrl はチャンネルのメタ情報のためJSONから直接参照する
 const homeUrl = ogenkidesukaFm.homeUrl;
 
 const lang = getLanguageFromURL(Astro.url.pathname);

--- a/src/components/page-index/sections/OgenkidesukaFmSection.astro
+++ b/src/components/page-index/sections/OgenkidesukaFmSection.astro
@@ -1,0 +1,31 @@
+---
+import { getLanguageFromURL, useTranslations } from "../../../i18n/util";
+import {
+  listOgenkidesukaFm,
+  ogenkidesukaFmUrl
+} from "../../../podcast/listPodcast";
+import GlobalListComponent from "../../global/GlobalListComponent.astro";
+
+const lang = getLanguageFromURL(Astro.url.pathname);
+const t = useTranslations(Astro);
+---
+
+<section id="ogenkidesuka-fm" aria-labelledby="ogenkidesuka-fm_heading">
+  <h2 id="ogenkidesuka-fm_heading">{t("heading.ogenkidesuka-fm")}</h2>
+  <p>{t("ogenkidesuka-fm.description")}</p>
+  <GlobalListComponent list={listOgenkidesukaFm} />
+  {
+    lang === "en" ? (
+      <p>
+        If you are looking for past episodes, please visit{" "}
+        <a href={ogenkidesukaFmUrl}>Spotify for Creators</a>.
+      </p>
+    ) : (
+      <p>
+        過去のエピソードをお探しの場合、
+        <a href={ogenkidesukaFmUrl}>Spotify for Creators</a>
+        より参照してください。
+      </p>
+    )
+  }
+</section>

--- a/src/components/page-index/sections/OgenkidesukaFmSection.astro
+++ b/src/components/page-index/sections/OgenkidesukaFmSection.astro
@@ -1,10 +1,13 @@
 ---
+import ogenkidesukaFm from "../../../data/ogenkidesukaFm.json";
 import { getLanguageFromURL, useTranslations } from "../../../i18n/util";
-import {
-  listOgenkidesukaFm,
-  ogenkidesukaFmUrl
-} from "../../../podcast/listPodcast";
 import GlobalListComponent from "../../global/GlobalListComponent.astro";
+import type { ListItem } from "../../global/GlobalTypes";
+
+// お元気ですか.fm のRSSから生成した最新エピソード一覧。
+// データは scripts/fetch-ogenkidesuka-fm.mjs が src/data/ogenkidesukaFm.json に生成する。
+const episodes: ListItem[] = ogenkidesukaFm.episodes;
+const homeUrl = ogenkidesukaFm.homeUrl;
 
 const lang = getLanguageFromURL(Astro.url.pathname);
 const t = useTranslations(Astro);
@@ -13,17 +16,17 @@ const t = useTranslations(Astro);
 <section id="ogenkidesuka-fm" aria-labelledby="ogenkidesuka-fm_heading">
   <h2 id="ogenkidesuka-fm_heading">{t("heading.ogenkidesuka-fm")}</h2>
   <p>{t("ogenkidesuka-fm.description")}</p>
-  <GlobalListComponent list={listOgenkidesukaFm} />
+  <GlobalListComponent list={episodes} />
   {
     lang === "en" ? (
       <p>
         If you are looking for past episodes, please visit{" "}
-        <a href={ogenkidesukaFmUrl}>Spotify for Creators</a>.
+        <a href={homeUrl}>Spotify for Creators</a>.
       </p>
     ) : (
       <p>
         過去のエピソードをお探しの場合、
-        <a href={ogenkidesukaFmUrl}>Spotify for Creators</a>
+        <a href={homeUrl}>Spotify for Creators</a>
         より参照してください。
       </p>
     )

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,19 @@
+import { defineCollection, z } from "astro:content";
+import { file } from "astro/loaders";
+
+// お元気ですか.fm の最新エピソード。
+// データは scripts/fetch-ogenkidesuka-fm.mjs が src/data/ogenkidesukaFm.json に生成する。
+// JSONは { feedUrl, homeUrl, episodes } 構造のため、parserでepisodes配列を取り出す。
+const ogenkidesukaFm = defineCollection({
+  loader: file("src/data/ogenkidesukaFm.json", {
+    parser: (text) => JSON.parse(text).episodes
+  }),
+  schema: z.object({
+    id: z.string(),
+    title: z.string(),
+    url: z.string().url(),
+    datetime: z.string().datetime()
+  })
+});
+
+export const collections = { ogenkidesukaFm };

--- a/src/data/ogenkidesukaFm.json
+++ b/src/data/ogenkidesukaFm.json
@@ -3,26 +3,31 @@
   "homeUrl": "https://podcasters.spotify.com/pod/show/ogenkidesuka-fm",
   "episodes": [
     {
+      "id": "8b674eed-73f3-4391-ad27-864c9f24cc9e",
       "title": "vol.45【ゲスト：naokihaba】Vite+ チームメンバーとお元気ですか",
       "url": "https://podcasters.spotify.com/pod/show/ogenkidesuka-fm/episodes/vol-45naokihabaVite-e3lqj36",
       "datetime": "2026-07-10T03:30:00.000Z"
     },
     {
+      "id": "cdf9711f-e7c7-4e4d-a322-3fcb522ed00e",
       "title": "vol.44 これからのカンファレンスについて考える",
       "url": "https://podcasters.spotify.com/pod/show/ogenkidesuka-fm/episodes/vol-44-e3l94li",
       "datetime": "2026-06-26T05:00:00.000Z"
     },
     {
+      "id": "b07758e5-50e7-4aec-98b8-719be13804f0",
       "title": "vol.43 アクセシビリティをより広げていくためにどうする？",
       "url": "https://podcasters.spotify.com/pod/show/ogenkidesuka-fm/episodes/vol-43-e3jl773",
       "datetime": "2026-05-21T10:00:00.000Z"
     },
     {
+      "id": "ce63f292-3e88-4a89-9788-4fee3e814b55",
       "title": "vol.42 技書博13にサークル参加してきました！",
       "url": "https://podcasters.spotify.com/pod/show/ogenkidesuka-fm/episodes/vol-42-13-e3jl75e",
       "datetime": "2026-05-21T10:00:00.000Z"
     },
     {
+      "id": "70123bff-b605-43c0-ab18-e22a643a6eb7",
       "title": "vol.41：【ゲスト：Kenji】お元気ですかリスナーと一緒にわいわい",
       "url": "https://podcasters.spotify.com/pod/show/ogenkidesuka-fm/episodes/vol-41Kenji-e3fsk89",
       "datetime": "2026-03-05T03:00:00.000Z"

--- a/src/data/ogenkidesukaFm.json
+++ b/src/data/ogenkidesukaFm.json
@@ -1,0 +1,31 @@
+{
+  "feedUrl": "https://anchor.fm/s/65c3f018/podcast/rss",
+  "homeUrl": "https://podcasters.spotify.com/pod/show/ogenkidesuka-fm",
+  "episodes": [
+    {
+      "title": "vol.45【ゲスト：naokihaba】Vite+ チームメンバーとお元気ですか",
+      "url": "https://podcasters.spotify.com/pod/show/ogenkidesuka-fm/episodes/vol-45naokihabaVite-e3lqj36",
+      "datetime": "2026-07-10T03:30:00.000Z"
+    },
+    {
+      "title": "vol.44 これからのカンファレンスについて考える",
+      "url": "https://podcasters.spotify.com/pod/show/ogenkidesuka-fm/episodes/vol-44-e3l94li",
+      "datetime": "2026-06-26T05:00:00.000Z"
+    },
+    {
+      "title": "vol.43 アクセシビリティをより広げていくためにどうする？",
+      "url": "https://podcasters.spotify.com/pod/show/ogenkidesuka-fm/episodes/vol-43-e3jl773",
+      "datetime": "2026-05-21T10:00:00.000Z"
+    },
+    {
+      "title": "vol.42 技書博13にサークル参加してきました！",
+      "url": "https://podcasters.spotify.com/pod/show/ogenkidesuka-fm/episodes/vol-42-13-e3jl75e",
+      "datetime": "2026-05-21T10:00:00.000Z"
+    },
+    {
+      "title": "vol.41：【ゲスト：Kenji】お元気ですかリスナーと一緒にわいわい",
+      "url": "https://podcasters.spotify.com/pod/show/ogenkidesuka-fm/episodes/vol-41Kenji-e3fsk89",
+      "datetime": "2026-03-05T03:00:00.000Z"
+    }
+  ]
+}

--- a/src/i18n/en/dictionary.ts
+++ b/src/i18n/en/dictionary.ts
@@ -20,6 +20,7 @@ export default Dictionary({
   "heading.contact": "Contact",
   "heading.open-source-activity": "Open Source Activity",
   "heading.daily-journal": "Daily journal",
+  "heading.ogenkidesuka-fm": "Ogenki-desuka.fm",
 
   // basic Info
   "info.real-name": "Real name",
@@ -43,6 +44,10 @@ export default Dictionary({
   // donate
   "donate.description":
     "If you are interested in my work, presentations and activities, you can donate me by.",
+
+  // ogenkidesuka.fm
+  "ogenkidesuka-fm.description":
+    "A podcast where I casually chat with takanorip about recent happenings, UI and product design, careers, life hacks, and more. Showing the latest episodes.",
 
   // multilingual
   multilingual: "Multilingual Page"

--- a/src/i18n/ja/dictionary.ts
+++ b/src/i18n/ja/dictionary.ts
@@ -18,6 +18,7 @@ export default {
   "heading.contact": "連絡先",
   "heading.open-source-activity": "オープンソース活動",
   "heading.daily-journal": "日報",
+  "heading.ogenkidesuka-fm": "お元気ですか.fm",
 
   // 基本情報
   "info.real-name": "本名",
@@ -41,6 +42,10 @@ export default {
   // 寄付・支援
   "donate.description":
     "もし私の制作物や発表、活動に興味をもっていただけた場合以下より支援することができます。",
+
+  // お元気ですか.fm
+  "ogenkidesuka-fm.description":
+    "takanoripと最近の近況、UIやプロダクトのデザイン、キャリアやライフハックなどについて雑に話すPodcastです。最新のエピソードを掲載しています。",
 
   // 多言語
   multilingual: "多言語ページ"

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -2,6 +2,7 @@
 import AddressSection from "../../components/page-index/sections/AddressSection.astro";
 import BasicInfoSection from "../../components/page-index/sections/BasicInfoSection.astro";
 import DailyJournalSection from "../../components/page-index/sections/DailyJournalSection.astro";
+import OgenkidesukaFmSection from "../../components/page-index/sections/OgenkidesukaFmSection.astro";
 // import OpenSourceActivitySection from "../../components/page-index/sections/OpenSourceActivitySection.astro";
 import PresentationsSection from "../../components/page-index/sections/PresentationsSection.astro";
 import SocialNetworkServicesSection from "../../components/page-index/sections/SocialNetworkServicesSection.astro";
@@ -24,6 +25,7 @@ import "../../styles/global.css";
     </BasicInfoSection>
     <!-- OpenSourceActivitySection -->
     <PresentationsSection />
+    <OgenkidesukaFmSection />
     <DailyJournalSection>
       <p>
         I utilize <a href="https://scrapbox.io/">Helpfeel Cosense</a> to compile daily events

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,7 @@
 import AddressSection from "../components/page-index/sections/AddressSection.astro";
 import BasicInfoSection from "../components/page-index/sections/BasicInfoSection.astro";
 import DailyJournalSection from "../components/page-index/sections/DailyJournalSection.astro";
+import OgenkidesukaFmSection from "../components/page-index/sections/OgenkidesukaFmSection.astro";
 // import OpenSourceActivitySection from "../components/page-index/sections/OpenSourceActivitySection.astro";
 import PresentationsSection from "../components/page-index/sections/PresentationsSection.astro";
 import SocialNetworkServicesSection from "../components/page-index/sections/SocialNetworkServicesSection.astro";
@@ -32,6 +33,7 @@ import "../styles/global.css";
     </BasicInfoSection>
     <!-- OpenSourceActivitySection -->
     <PresentationsSection />
+    <OgenkidesukaFmSection />
     <DailyJournalSection>
       <p>
         <a href="https://scrapbox.io/">Helpfeel Cosense</a

--- a/src/podcast/listPodcast.ts
+++ b/src/podcast/listPodcast.ts
@@ -1,8 +1,0 @@
-import type { ListItem } from "../components/global/GlobalTypes";
-import ogenkidesukaFm from "../data/ogenkidesukaFm.json";
-
-// お元気ですか.fm のRSSから生成した最新エピソード一覧。
-// データは scripts/fetch-ogenkidesuka-fm.mjs が src/data/ogenkidesukaFm.json に生成する。
-export const listOgenkidesukaFm: ListItem[] = ogenkidesukaFm.episodes;
-
-export const ogenkidesukaFmUrl = ogenkidesukaFm.homeUrl;

--- a/src/podcast/listPodcast.ts
+++ b/src/podcast/listPodcast.ts
@@ -1,0 +1,8 @@
+import type { ListItem } from "../components/global/GlobalTypes";
+import ogenkidesukaFm from "../data/ogenkidesukaFm.json";
+
+// お元気ですか.fm のRSSから生成した最新エピソード一覧。
+// データは scripts/fetch-ogenkidesuka-fm.mjs が src/data/ogenkidesukaFm.json に生成する。
+export const listOgenkidesukaFm: ListItem[] = ogenkidesukaFm.episodes;
+
+export const ogenkidesukaFmUrl = ogenkidesukaFm.homeUrl;


### PR DESCRIPTION
## 概要

お元気ですか.fm のRSSフィード（`https://anchor.fm/s/65c3f018/podcast/rss`）をもとに、トップページに最新5話を表示する「お元気ですか.fm」セクションを追加し、RSS更新時に自動デプロイするワークフローを追加します。

## 変更内容

### セクション追加
- `src/components/page-index/sections/OgenkidesukaFmSection.astro` を新規作成し、`src/pages/index.astro` / `src/pages/en/index.astro` の発表一覧の直後に配置
- 既存の `GlobalListComponent` で最新5話（タイトル・日時・リンク）を一覧表示
- i18n辞書（ja/en）に見出し・説明文を追加。過去エピソードへの導線は文中の「Spotify for Creators」リンクで表現

### データ生成
- `scripts/fetch-ogenkidesuka-fm.mjs`：外部依存なし（Node標準`fetch`）でRSSを取得し、最新5話とホームURLを `src/data/ogenkidesukaFm.json` に出力。データ欠損時は失敗させる
- `src/podcast/listPodcast.ts`：JSONを型安全（`ListItem[]`）に読み込むローダー

### 自動更新・デプロイ
- `.github/workflows/update-ogenkidesuka-fm.yml`：毎日 00:00 UTC（09:00 JST）＋手動実行でRSSを再取得し、`src/data/ogenkidesukaFm.json` に**差分があるときだけ** `main` にコミット＆push。`main` への push で Cloudflare Pages の自動デプロイがトリガーされる

## 確認事項
- `pnpm build` / `pnpm run biome` / `pnpm run markuplint` すべてパス
- 日英両ページで最新5話が正しく描画されることを確認済み
- ポッドキャストのリンク先はRSSチャンネルの `<link>`（Spotify for Creators）を採用。専用ドメインがあれば差し替え可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)